### PR TITLE
C4 container and component external artifacts

### DIFF
--- a/C4_Component.puml
+++ b/C4_Component.puml
@@ -11,6 +11,7 @@
 ' ##################################
 
 !define COMPONENT_BG_COLOR #85BBF0
+!define EXTERNAL_COMPONENT_BG_COLOR #BBBBBB
 
 ' Styling
 ' ##################################
@@ -29,6 +30,20 @@ skinparam database<<component>> {
     BorderColor #78A8D8
 }
 
+skinparam rectangle<<external_component>> {
+    StereotypeFontColor ELEMENT_FONT_COLOR
+    FontColor #000000
+    BackgroundColor EXTERNAL_COMPONENT_BG_COLOR
+    BorderColor #8A8A8A
+}
+
+skinparam database<<external_component>> {
+    StereotypeFontColor ELEMENT_FONT_COLOR
+    FontColor #000000
+    BackgroundColor EXTERNAL_COMPONENT_BG_COLOR
+    BorderColor #8A8A8A
+}
+
 ' Layout
 ' ##################################
 
@@ -42,6 +57,8 @@ legend right
 |<EXTERNAL_SYSTEM_BG_COLOR>      | external system |
 |<CONTAINER_BG_COLOR>   | container |
 |<COMPONENT_BG_COLOR>   | component |
+|<EXTERNAL_CONTAINER_BG_COLOR>   | external container |
+|<EXTERNAL_COMPONENT_BG_COLOR>   | external component |
 endlegend
 !enddefinelong
 
@@ -53,3 +70,10 @@ endlegend
 
 !define ComponentDb(e_alias, e_label, e_techn) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<component>> as e_alias
 !define ComponentDb(e_alias, e_label, e_techn, e_descr) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<component>> as e_alias
+
+
+!define Component_Ext(e_alias, e_label, e_techn) rectangle "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<external_component>> as e_alias
+!define Component_Ext(e_alias, e_label, e_techn, e_descr) rectangle "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<external_component>> as e_alias
+
+!define ComponentDb_Ext(e_alias, e_label, e_techn) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<external_component>> as e_alias
+!define ComponentDb_Ext(e_alias, e_label, e_techn, e_descr) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<external_component>> as e_alias

--- a/C4_Container.puml
+++ b/C4_Container.puml
@@ -11,6 +11,7 @@
 ' ##################################
 
 !define CONTAINER_BG_COLOR #438DD5
+!define EXTERNAL_CONTAINER_BG_COLOR #AAAAAA
 
 ' Styling
 ' ##################################
@@ -29,6 +30,20 @@ skinparam database<<container>> {
     BorderColor #3C7FC0
 }
 
+skinparam rectangle<<external_container>> {
+    StereotypeFontColor ELEMENT_FONT_COLOR
+    FontColor ELEMENT_FONT_COLOR
+    BackgroundColor EXTERNAL_CONTAINER_BG_COLOR
+    BorderColor #8A8A8A
+}
+
+skinparam database<<external_container>> {
+    StereotypeFontColor ELEMENT_FONT_COLOR
+    FontColor ELEMENT_FONT_COLOR
+    BackgroundColor EXTERNAL_CONTAINER_BG_COLOR
+    BorderColor #8A8A8A
+}
+
 ' Layout
 ' ##################################
 
@@ -41,6 +56,7 @@ legend right
 |<SYSTEM_BG_COLOR>   | system |
 |<EXTERNAL_SYSTEM_BG_COLOR>      | external system |
 |<CONTAINER_BG_COLOR>   | container |
+|<EXTERNAL_CONTAINER_BG_COLOR>   | external container |
 endlegend
 !enddefinelong
 
@@ -52,6 +68,13 @@ endlegend
 
 !define ContainerDb(e_alias, e_label, e_techn) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<container>> as e_alias
 !define ContainerDb(e_alias, e_label, e_techn, e_descr) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<container>> as e_alias
+
+!define Container_Ext(e_alias, e_label, e_techn) rectangle "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<external_container>> as e_alias
+!define Container_Ext(e_alias, e_label, e_techn, e_descr) rectangle "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<external_container>> as e_alias
+
+!define ContainerDb_Ext(e_alias, e_label, e_techn) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<external_container>> as e_alias
+!define ContainerDb_Ext(e_alias, e_label, e_techn, e_descr) database "==e_label\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<external_container>> as e_alias
+
 
 ' Boundaries
 ' ##################################


### PR DESCRIPTION
For well-designed systems current set of C4-PalntUML artifacts are sufficient.
When working with monoliths a.k.a "Big Ball of Mud" we have an issue with correctly distinguish which container and/or component
is under the team responsibility. Some containers/components are relevant from use-case perspective. Therefore, they should be 
present on a diagram to give full use-case picture. In the same time they should be marked as "external" 
as team is not responsible nor develop them. This can be easily achieved by introducing "external" container/component artifacts in C4-PlantUML.