### PR TITLE
Show person icon in personas box

### DIFF
--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -60,6 +60,9 @@ skinparam database<<external_system>> {
     BorderColor #8A8A8A
 }
 
+!define ICON_SCALE 6
+!define PERSON_ICON <&person,scale=ICON_SCALE>
+
 ' Layout
 ' ##################################
 
@@ -77,11 +80,11 @@ endlegend
 ' Elements
 ' ##################################
 
-!define Person(e_alias, e_label) rectangle "==e_label" <<person>> as e_alias
-!define Person(e_alias, e_label, e_descr) rectangle "==e_label\n\n e_descr" <<person>> as e_alias
+!define Person(e_alias, e_label) rectangle "PERSON_ICON\n ==e_label" <<person>> as e_alias
+!define Person(e_alias, e_label, e_descr) rectangle "PERSON_ICON\n ==e_label\n\n e_descr" <<person>> as e_alias
 
-!define Person_Ext(e_alias, e_label) rectangle "==e_label" <<external_person>> as e_alias
-!define Person_Ext(e_alias, e_label, e_descr) rectangle "==e_label\n\n e_descr" <<external_person>> as e_alias
+!define Person_Ext(e_alias, e_label) rectangle "PERSON_ICON\n ==e_label" <<external_person>> as e_alias
+!define Person_Ext(e_alias, e_label, e_descr) rectangle "PERSON_ICON\n ==e_label\n\n e_descr" <<external_person>> as e_alias
 
 !define System(e_alias, e_label) rectangle "==e_label" <<system>> as e_alias
 !define System(e_alias, e_label, e_descr) rectangle "==e_label\n\n e_descr" <<system>> as e_alias


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52084106/81484610-1fad3600-9247-11ea-97ef-fcb52c93ab5a.png)


Renders Person and Person_Ext with portrait icon inside rectangle. This makes human users of 
 software system more clearer in the diagrams.