### PR TITLE
Add color override option

### DIFF
--- a/C4_Component.puml
+++ b/C4_Component.puml
@@ -10,23 +10,31 @@
 ' Colors
 ' ##################################
 
+!ifndef COMPONENT_FONT_COLOR
+!define COMPONENT_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef COMPONENT_BG_COLOR
 !define COMPONENT_BG_COLOR #85BBF0
+!endif
+!ifndef COMPONENT_BORDER_COLOR
+!define COMPONENT_BORDER_COLOR #78A8D8
+!endif
 
 ' Styling
 ' ##################################
 
 skinparam rectangle<<component>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor #000000
+    StereotypeFontColor COMPONENT_FONT_COLOR
+    FontColor COMPONENT_FONT_COLOR
     BackgroundColor COMPONENT_BG_COLOR
-    BorderColor #78A8D8
+    BorderColor COMPONENT_BORDER_COLOR
 }
 
 skinparam database<<component>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor #000000
+    StereotypeFontColor COMPONENT_FONT_COLOR
+    FontColor COMPONENT_FONT_COLOR
     BackgroundColor COMPONENT_BG_COLOR
-    BorderColor #78A8D8
+    BorderColor COMPONENT_BORDER_COLOR
 }
 
 ' Layout

--- a/C4_Container.puml
+++ b/C4_Container.puml
@@ -10,23 +10,31 @@
 ' Colors
 ' ##################################
 
+!ifndef CONTAINER_FONT_COLOR
+!define CONTAINER_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef CONTAINER_BG_COLOR
 !define CONTAINER_BG_COLOR #438DD5
+!endif
+!ifndef CONTAINER_BORDER_COLOR
+!define CONTAINER_BORDER_COLOR #3C7FC0
+!endif
 
 ' Styling
 ' ##################################
 
 skinparam rectangle<<container>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor CONTAINER_FONT_COLOR
+    FontColor CONTAINER_FONT_COLOR
     BackgroundColor CONTAINER_BG_COLOR
-    BorderColor #3C7FC0
+    BorderColor CONTAINER_BORDER_COLOR
 }
 
 skinparam database<<container>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor CONTAINER_FONT_COLOR
+    FontColor CONTAINER_FONT_COLOR
     BackgroundColor CONTAINER_BG_COLOR
-    BorderColor #3C7FC0
+    BorderColor CONTAINER_BORDER_COLOR
 }
 
 ' Layout

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -10,54 +10,86 @@
 ' Colors
 ' ##################################
 
+!ifndef PERSON_FONT_COLOR
+!define PERSON_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef PERSON_BG_COLOR
 !define PERSON_BG_COLOR #08427B
+!endif
+!ifndef PERSON_BORDER_COLOR
+!define PERSON_BORDER_COLOR #073B6F
+!endif
+!ifndef EXTERNAL_PERSON_FONT_COLOR
+!define EXTERNAL_PERSON_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef EXTERNAL_PERSON_BG_COLOR
 !define EXTERNAL_PERSON_BG_COLOR #686868
+!endif
+!ifndef EXTERNAL_PERSON_BORDER_COLOR
+!define EXTERNAL_PERSON_BORDER_COLOR #8A8A8A
+!endif
+!ifndef SYSTEM_FONT_COLOR
+!define SYSTEM_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef SYSTEM_BG_COLOR
 !define SYSTEM_BG_COLOR #1168BD
+!endif
+!ifndef SYSTEM_BORDER_COLOR
+!define SYSTEM_BORDER_COLOR #3C7FC0
+!endif
+!ifndef EXTERNAL_SYSTEM_FONT_COLOR
+!define EXTERNAL_SYSTEM_FONT_COLOR ELEMENT_FONT_COLOR
+!endif
+!ifndef EXTERNAL_SYSTEM_BG_COLOR
 !define EXTERNAL_SYSTEM_BG_COLOR #999999
+!endif
+!ifndef EXTERNAL_SYSTEM_BORDER_COLOR
+!define EXTERNAL_SYSTEM_BORDER_COLOR #8A8A8A
+!endif
 
 ' Styling
 ' ##################################
 
 skinparam rectangle<<person>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor PERSON_FONT_COLOR
+    FontColor PERSON_FONT_COLOR
     BackgroundColor PERSON_BG_COLOR
-    BorderColor #073B6F
+    BorderColor PERSON_BORDER_COLOR
 }
 
 skinparam rectangle<<external_person>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor EXTERNAL_PERSON_FONT_COLOR
+    FontColor EXTERNAL_PERSON_FONT_COLOR
     BackgroundColor EXTERNAL_PERSON_BG_COLOR
-    BorderColor #8A8A8A
+    BorderColor EXTERNAL_PERSON_BORDER_COLOR
 }
 
 skinparam rectangle<<system>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor SYSTEM_FONT_COLOR
+    FontColor SYSTEM_FONT_COLOR
     BackgroundColor SYSTEM_BG_COLOR
-    BorderColor #3C7FC0
+    BorderColor SYSTEM_BORDER_COLOR
 }
 
 skinparam rectangle<<external_system>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor EXTERNAL_SYSTEM_FONT_COLOR
+    FontColor EXTERNAL_SYSTEM_FONT_COLOR
     BackgroundColor EXTERNAL_SYSTEM_BG_COLOR
-    BorderColor #8A8A8A
+    BorderColor EXTERNAL_SYSTEM_BORDER_COLOR
 }
 
 skinparam database<<system>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor SYSTEM_FONT_COLOR
+    FontColor SYSTEM_FONT_COLOR
     BackgroundColor SYSTEM_BG_COLOR
-    BorderColor #3C7FC0
+    BorderColor SYSTEM_BORDER_COLOR
 }
 
 skinparam database<<external_system>> {
-    StereotypeFontColor ELEMENT_FONT_COLOR
-    FontColor ELEMENT_FONT_COLOR
+    StereotypeFontColor EXTERNAL_SYSTEM_FONT_COLOR
+    FontColor EXTERNAL_SYSTEM_FONT_COLOR
     BackgroundColor EXTERNAL_SYSTEM_BG_COLOR
-    BorderColor #8A8A8A
+    BorderColor EXTERNAL_SYSTEM_BORDER_COLOR
 }
 
 ' Layout


### PR DESCRIPTION
By defining any of the used colors before including the C4 libraries, colors can be overridden.

```
!define SYSTEM_BG_COLOR #ff0000
!include <C4/C4_Context>

System(foo, "Foo")
```

For completeness, I also added color defines for the rest of the used colors. The complete list now reads:
```
PERSON_FONT_COLOR
PERSON_BG_COLOR
PERSON_BORDER_COLOR
EXTERNAL_PERSON_FONT_COLOR
EXTERNAL_PERSON_BG_COLOR
EXTERNAL_PERSON_BORDER_COLOR
SYSTEM_FONT_COLOR
SYSTEM_BG_COLOR
SYSTEM_BORDER_COLOR
EXTERNAL_SYSTEM_FONT_COLOR
EXTERNAL_SYSTEM_BG_COLOR
EXTERNAL_SYSTEM_BORDER_COLOR
CONTAINER_FONT_COLOR
CONTAINER_BG_COLOR
CONTAINER_BORDER_COLOR
COMPONENT_FONT_COLOR
COMPONENT_BG_COLOR
COMPONENT_BORDER_COLOR
```
