### PR TITLE
Fixes percy diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Entities can also be decorated with icons using the last parameter, for example:
 ```cs
 @startuml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
-' uncomment the following line and comment the first to use locally
-' !include C4_Container.puml
 
 !define DEVICONS https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master/devicons
 !define FONTAWESOME https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master/font-awesome-5

--- a/percy/C4_Container Diagram Sample - bigbankplc.puml
+++ b/percy/C4_Container Diagram Sample - bigbankplc.puml
@@ -3,7 +3,7 @@
 !include ./../C4_Context.puml
 !include ./../C4.puml
 
-LAYOUT_TOP_DOWN
+LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()
 LAYOUT_WITH_LEGEND()
 

--- a/percy/C4_Container Diagram Sample - message bus.puml
+++ b/percy/C4_Container Diagram Sample - message bus.puml
@@ -6,7 +6,7 @@
 skinparam wrapWidth 200
 skinparam maxMessageSize 200
 
-LAYOUT_TOP_DOWN
+LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()
 LAYOUT_WITH_LEGEND()
 

--- a/percy/C4_Container Diagram Sample - techtribesjs.puml
+++ b/percy/C4_Container Diagram Sample - techtribesjs.puml
@@ -3,7 +3,7 @@
 !include ./../C4_Context.puml
 !include ./../C4.puml
 
-LAYOUT_TOP_DOWN
+LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()
 LAYOUT_WITH_LEGEND()
 

--- a/percy/C4_Context Diagram Sample - bigbankplc-landscape.puml
+++ b/percy/C4_Context Diagram Sample - bigbankplc-landscape.puml
@@ -2,8 +2,8 @@
 !include ./../C4_Context.puml
 !include ./../C4.puml
 
-'LAYOUT_TOP_DOWN
-'LAYOUT_AS_SKETCH
+'LAYOUT_TOP_DOWN()
+'LAYOUT_AS_SKETCH()
 LAYOUT_WITH_LEGEND()
 
 title System Landscape diagram for Big Bank plc

--- a/percy/C4_Context Diagram Sample - enterprise.puml
+++ b/percy/C4_Context Diagram Sample - enterprise.puml
@@ -2,7 +2,7 @@
 !include ./../C4_Context.puml
 !include ./../C4.puml
 
-LAYOUT_TOP_DOWN
+LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()
 LAYOUT_WITH_LEGEND()
 


### PR DESCRIPTION
Adds () to LAYOUT_TOP_DOWN() in percy diagrams and removes a comment from the readme diagram examples. I will merge this right away to have a complete master branch