### PR TITLE
#124 Remove not working, misleading and unused default values

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -319,10 +319,10 @@ rectangle "$getBoundary($label, $type)" $toStereos("boundary", $tags) as $alias
 ' Relationship
 ' ##################################
 
-!unquoted procedure Rel_($alias1, $alias2, $label, $direction="")
+!unquoted procedure Rel_($alias1, $alias2, $label, $direction)
 $alias1 $direction $alias2 : **$label**
 !endprocedure
-!unquoted procedure Rel_($alias1, $alias2, $label, $techn, $direction="")
+!unquoted procedure Rel_($alias1, $alias2, $label, $techn, $direction)
 $alias1 $direction $alias2 : **$label**\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//
 !endprocedure
 


### PR DESCRIPTION
the Rel_() definitions with the default argument $direction=""
```
!unquoted procedure Rel_($alias1, $alias2, $label, $direction="")
!unquoted procedure Rel_($alias1, $alias2, $label, $techn, $direction="")
```
are (details see #124)
1. not working with default values (if $direction is "" an invalid PlantUML syntax is created)
2. if a user uses Rel_() with 4 arguments then it is not clear whether the system uses the first or second definition. (after check. first defintion is used)
 
Therefore the default values are only missleading and not usable and should be removed.
BR Helmut