### PR TITLE
#128: Some boundary skinparam have to be set a package skinparams too

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -49,6 +49,12 @@ skinparam Arrow {
     FontSize 12
 }
 
+' Some boundary skinparam have to be set a package skinparams too (PlantUML uses internal packages)
+skinparam package {
+    StereotypeFontSize 0
+    FontStyle plain
+}
+
 skinparam rectangle<<boundary>> {
     Shadowing false
     StereotypeFontSize 0


### PR DESCRIPTION
PlantUML realises all boundaries via packages therefore following package specific skinparams have to be set that the boundaries correspond with the defined `rectangle<<boundary>>` style (techn. text should be not bold and no sterotype should be displayed).

```
skinparam package {
    StereotypeFontSize 0
    FontStyle plain
}
```

current master branch without bugfix 
```
@startuml
!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml

System_Boundary(c1, "Sample System Boundary") {
   System(twitter, "Twitter")
}

System_Boundary(c2, "Sample System2 Boundary") {
}
@enduml
```
![](http://www.plantuml.com/plantuml/png/ROp12u8m58Vl-okM9uLq99qwILuB0kiiSnivsEROtZ09__SSrg7ezlX-x_ig3zH1q0fjf64gS85x0EiFX3Ww5dS9VUY25uuD1eI1WWsQM4LDT78FNCcErFly4j7jV2AQUX1kGMqTZGSKDjPHCorSjySX64xTbBBT5YSDrLO9l6xuioKPVYACtpY5KG88jxnVrol9qFmdMFu6o-_YZ2fXUD3g1G00)

my local branch with bugfix
```
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml

System_Boundary(c1, "Sample System Boundary") {
   System(twitter, "Twitter")
}

System_Boundary(c2, "Sample System2 Boundary") {
}
@enduml
```
![](http://www.plantuml.com/plantuml/png/ROungy8m54Rt_8gyJYsyr_2AarEngu9GdKjCBYQOf2MveHRfVpTI7HItotSEXri7v1wZDUH7Es6Y1AeGXx1cpFEnF6jKyHG3UD4x18Ubw2sxQ2zKGCMQrT_US8V7tPR1DN49CerTasIk7VXoUAH9EmK4sstww2JtKox-VsdMSZiOe0kZBvOLz4OeVSuvZXeHVD8FovKLPFuIh3w3rNjn9ZKucPwv0m00)

All other styles (like color and shadow) can be set via the rectangle specific skinparams (no additional package specific definitions are required).

This PR should fix #128 


