### PR TITLE
#113: Restore SystemDb and SystemDb_Ext

### DIFF
--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -218,6 +218,14 @@ rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", 
 rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias
 !endprocedure
 
+!unquoted procedure SystemDb($alias, $label, $descr="", $sprite="", $tags="")
+database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias
+!endprocedure
+
+!unquoted procedure SystemDb_Ext($alias, $label, $descr="", $sprite="", $tags="")
+database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias
+!endprocedure
+
 ' Boundaries
 ' ##################################
 


### PR DESCRIPTION
Added SystemDb and SystemDb_Ext with full style support.
(I use my ...extended... urls that the preview is working)

```
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml

System(foo, "Foo")
SystemDb(bar, "Bar")
SystemDb_Ext(bar_ext, "Bar Ext")

Rel(foo, bar, "Baz")
Rel(foo, bar_ext, "Baz")
@enduml
```
![](http://www.plantuml.com/plantuml/png/JOun3u8m58Jt_WfamaJfukH4H9qqCHfdKihJDfQMjAyH_VK-WXhMxxkxN15GU8ojOJDjfOaD90gn2slElNZcTuqgrZ60byuYMCobQ_b3Uwa2AbwkbYSZB5wF1muz-GOQWbL9OQ4j-BmRfXcxl092czsSMoJfthbq_aNREgk59xWHVWAhNO-3g6Xrb0aH2h0pc77cLtiJdSAXyXS5NQ877m00) 

This PR should fix #113 

BR Helmut