### PR TITLE
#133, #48: fix StereotypeFontSize 0 and StereotypeFontColor problem

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -8,6 +8,7 @@
 !global $ARROW_COLOR = "#666666"
 
 !global $BOUNDARY_COLOR = "#444444"
+!global $BOUNDARY_BG_COLOR = "#FFFFFF"
 
 !global $LEGEND_FONT_COLOR = "#FFFFFF"
 !global $LEGEND_TITLE_COLOR = "#000000"
@@ -51,15 +52,19 @@ skinparam Arrow {
 
 ' Some boundary skinparam have to be set a package skinparams too (PlantUML uses internal packages)
 skinparam package {
-    StereotypeFontSize 0
+    StereotypeFontSize 6
+    StereotypeFontColor $BOUNDARY_BG_COLOR
     FontStyle plain
+    BackgroundColor $BOUNDARY_BG_COLOR
 }
 
 skinparam rectangle<<boundary>> {
     Shadowing false
-    StereotypeFontSize 0
+    StereotypeFontSize 6
+    StereotypeFontColor $BOUNDARY_BG_COLOR
     FontColor $BOUNDARY_COLOR
     BorderColor $BOUNDARY_COLOR
+    BackgroundColor $BOUNDARY_BG_COLOR
     BorderStyle dashed
 }
 
@@ -119,6 +124,10 @@ skinparam rectangle<<boundary>> {
   !$tagSkin = $elementTagSkinparams("rectangle", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
   !$tagSkin = $tagSkin + $elementTagSkinparams("database", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
   !$tagSkin = $tagSkin + $elementTagSkinparams("queue", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
+  !if ($tagStereo == "boundary")
+    !$tagSkin = $tagSkin + "skinparam package<<boundary>>StereotypeFontColor " + $bgColor + %newline()
+    !$tagSkin = $tagSkin + "skinparam rectangle<<boundary>>StereotypeFontColor " + $bgColor + %newline()
+  !endif
 $tagSkin
 !endprocedure
 

--- a/C4.puml
+++ b/C4.puml
@@ -101,7 +101,9 @@ skinparam rectangle<<boundary>> {
 !function $elementTagSkinparams($element, $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
   !$elementSkin = "skinparam " + $element +"<<" + $tagStereo + ">> {" + %newline()
   !if ($fontColor!="")
-    !$elementSkin = $elementSkin + "    StereotypeFontColor " + $fontColor + %newline()
+    !if ($tagStereo != "boundary")
+      !$elementSkin = $elementSkin + "    StereotypeFontColor " + $fontColor + %newline()
+    !endif
     !$elementSkin = $elementSkin + "    FontColor " + $fontColor + %newline()
   !endif
   !if ($bgColor!="")
@@ -124,7 +126,7 @@ skinparam rectangle<<boundary>> {
   !$tagSkin = $elementTagSkinparams("rectangle", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
   !$tagSkin = $tagSkin + $elementTagSkinparams("database", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
   !$tagSkin = $tagSkin + $elementTagSkinparams("queue", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing)
-  !if ($tagStereo == "boundary")
+  !if ($tagStereo == "boundary" && $bgColor!="")
     !$tagSkin = $tagSkin + "skinparam package<<boundary>>StereotypeFontColor " + $bgColor + %newline()
     !$tagSkin = $tagSkin + "skinparam rectangle<<boundary>>StereotypeFontColor " + $bgColor + %newline()
   !endif


### PR DESCRIPTION
Hi,

I update the boundary skinparams, ... the 0 size should be fixed (new size 6) and the stereotypetext is drawn with the backgroundcolor (==remains invisible)

It can be tested via my [extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended)

```
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml

!$COLOR_A_5 = "#7f3b08"
!$COLOR_A_4 = "#b35806"
!$COLOR_A_3 = "#e08214"
!$COLOR_A_2 = "#fdb863"
!$COLOR_A_1 = "#fee0b6"
!$COLOR_NEUTRAL = "#f7f7f7"
!$COLOR_B_1 = "#d8daeb"
!$COLOR_B_2 = "#b2abd2"
!$COLOR_B_3 = "#8073ac"
!$COLOR_B_4 = "#542788"
!$COLOR_B_5 = "#2d004b"

' master doesn't have the new method names
' UpdateSkinparamsAndLegendEntry("boundary", $bgColor=$COLOR_A_5, $fontColor=$COLOR_NEUTRAL, $borderColor=$COLOR_A_1, $shadowing="true")

' my extended supports the new names
UpdateElementStyle("boundary", $bgColor=$COLOR_A_5, $fontColor=$COLOR_NEUTRAL, $borderColor=$COLOR_A_1, $shadowing="true")

System_Boundary(c1, "Sample System") {
    Container(web_app, "Web Application", "C#, ASP.NET Core 2.1 MVC", "Allows users to compare multiple Twitter timelines")
}

System_Boundary(c2, "Sample System") {
}
@enduml
```
![](http://www.plantuml.com/plantuml/png/lP9VRzem5CNV-HItQQLIgOCGe4IJa9f6lD4_Ah0z8Zk-aAZ-Ozatoz2qxpv3EXfDVLxozZldtdFivDuJSrGhsRkeT25hWL0IMVzrE7Ii6UmhAcjUUtI5qOIQ1eLHmxVA5QMdSfXFlhn8fcdpk1pYpw0B505kys1cbKOtiCVLlOkh_7dv_BhDjbEOGtGvsurvd4OTFZbnFfwcyLsNZqySupGPJReyEV6TuEdTkCj7BKUCUMVFqsApVisMhJOxlX_Qm_kCI0L3tkLj1ayO5qcNjvtIU3PcHPUtPvXEabcQTdbxvaJ4yIJixrs3OfxGWJ3ezJL1oNuWK8cWiG65L1e1cYdqmRgnWX6ktYfjcMFAPreiSOzQB3IvGp_YfjQ2kKDq2rTydnjftFpZiWFS6KqTVBwBezyuWUwVcL4GVCc4QIgzdqVaQenkJgKFyFSJWw-jDOxykNLRjosxaAXGqueE4lzVmTN14whjmtjSlmY-QCMKbGYj5jt0hnw4v_ntzXlaMsPjS7v73fcriYeOLKP70UMNjv2jNWPFYtKOSGZ9O0IFt_AZbabf6W-rH-U131H6MHOigfPK7IFNJKM43gXIA4EM3nr_Vz8o-QnbSDwZ5hMIVm00)

BR Helmut
