### PR TITLE
#215 Lay_x calls supports long version Lay_xxxx too

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -1117,13 +1117,28 @@ $getRel($right("<<-","->>"), $from, $to, $label, $techn, $descr, $sprite, $tags,
 !unquoted procedure Lay_D($from, $to)
 $from -[hidden]D- $to
 !endprocedure
+!unquoted procedure Lay_Down($from, $to)
+$from -[hidden]D- $to
+!endprocedure
+
 !unquoted procedure Lay_U($from, $to)
 $from -[hidden]U- $to
 !endprocedure
+!unquoted procedure Lay_Up($from, $to)
+$from -[hidden]U- $to
+!endprocedure
+
 !unquoted procedure Lay_R($from, $to)
 $from -[hidden]R- $to
 !endprocedure
+!unquoted procedure Lay_Right($from, $to)
+$from -[hidden]R- $to
+!endprocedure
+
 !unquoted procedure Lay_L($from, $to)
+$from -[hidden]L- $to
+!endprocedure
+!unquoted procedure Lay_Left($from, $to)
 $from -[hidden]L- $to
 !endprocedure
 

--- a/README.md
+++ b/README.md
@@ -283,12 +283,12 @@ Rel_D(user, user1, "requests", "async message", "if sprite starts with &, it def
 
 ![Relation with sprite or OpenIconic](https://www.plantuml.com/plantuml/png/bLJVQnin37w_lq8DeMiXoQN9DiWWKDPnCDRHqjBdujXAOkgpRvPlMHdxt-SVSPEikK7rujCdIzyd8TybEMPTMwlYH6gkMe6mTgwXJsLfsMQqacxTBbf2oursgDs8cxfi5DCXPqXEABaehzuFRmFqyFswh1avj1vwl0ePlzoe2TMBMxHaz5aeDO3UWpzwv_lWnHQ5YqDyal798JxD-DJZnVspPwtFA1u-almGUGVQs9efeCPAXmJC8ZXZO25NKDoXUhpUYifiKYzz1lNy9pUjbMZ3PtSL7-qdUDvhei198YRE58g35FCKAU_sAAUTb4VoRxuTOHl4Y_Fnw4FYvQPUI8tRH61Q92bUC33GkDb6YfF-zgguxwpu1hsvMBVYV_YysZ2c1haCe_NpLMXViZdJiC30AOg4GTzPoVHA8VmkmDjuPpk_ElIhpzN__6escrNTVlKnMDNbLzDaLPUVRVnAxvyysRJyBwjhh40RHniUOZZZOF9O1g3a4u9R8oGyZsH_CJAMza4kyoh4nqwmaMuDfuEC2bnAZGGCRXhKNxdHaWyywfXK18IxNuBNAcCu_WQClrt6BhxizYC-P8i_MYGNks3qh3dKICHM681EET8TbP8QFaNz4vMd779b2CMkNPX3xrNqlBX4BTfQ_GK0 "Relation with sprite or OpenIconic")
 
-In rare cases, you can force the layout of objects which have no relationships by using:
+In rare cases, you can force the layout of elements which have no relationships by using:
 
-* `Lay_U(from, to)`
-* `Lay_D(from, to)`
-* `Lay_L(from, to)`
-* `Lay_R(from, to)`
+* `Lay_U(from, to)`, `Lay_Up(from, to)`
+* `Lay_D(from, to)`, `Lay_Down(from, to)`
+* `Lay_L(from, to)`, `Lay_Left(from, to)`
+* `Lay_R(from, to)`, `Lay_Right(from, to)`
 
 In following sample a person uses different systems, and group of persons which have no relations
 

--- a/percy/TestLayDirections.puml
+++ b/percy/TestLayDirections.puml
@@ -1,0 +1,32 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include ./../C4_Container.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!endif
+
+HIDE_STEREOTYPE()
+
+Person(a, "A")
+Person(a1, "P1")
+Person(a2, "P2")
+Person(a3, "P3")
+Person(a4, "P4")
+
+Lay_U(a, a1)
+Lay_R(a, a2)
+Lay_D(a, a3)
+Lay_L(a, a4)
+
+Person(x, "X")
+System(s1, "S1")
+System(s2, "S2")
+System(s3, "S3")
+System(s4, "S4")
+
+Lay_Up(x, s1)
+Lay_Right(x, s2)
+Lay_Down(x, s3)
+Lay_Left(x, s4)
+@enduml


### PR DESCRIPTION
Implementation of https://github.com/plantuml-stdlib/C4-PlantUML/issues/215

"long" layout calls (`Lay_Up`, `Lay_Right`, `Lay_Down` and `Lay_Left`) can be used like below

```plantuml
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml
HIDE_STEREOTYPE()

Person(a, "A")
Person(b, "B")
Person(c, "C")
Person(d, "D")
Person(e, "E")

Lay_U(a, b)
Lay_R(a, c)
Lay_D(a, d)
Lay_L(a, e)

Person(x, "X")
System(s1, "S1")
System(s2, "S2")
System(s3, "S3")
System(s4, "S4")

Lay_Up(x, s1)
Lay_Right(x, s2)
Lay_Down(x, s3)
Lay_Left(x, s4)
@enduml
```

![](https://www.plantuml.com/plantuml/png/JP1DQxD058Nt_egyMIcyLVnOTPLMXHOibPX0kv9nvZPATPIPAqd-VU-ehUxEyrmv7kQWaIaSkzRwrqZUZW9sDUAW7prFiQjxQR0Ugr63uhr4aEZollE-6yLhZRKNHmzvooIUtp8FRdGN84YMCNtC6WdA7KproskIbiKfFQRlfyyyjHtBoa7fNjhi_sx_j7T-iI9yNf4JnYiAmcH584m9hOpToxEfgfmf7qtcSqvC5dFEJ8RrvpSg-A22uguHEblxn8M_4O4HmKQ4HeGR4HaH_OqOJAVsbndDfSP91CkM_Yed3fSzy3NV8ySwW1JqL3y0)

It can be tested with [my extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended)

BR Helmut

PS.: I didn't add something to LayoutOptions.md because I think it is not an option
 