### PR TITLE
#227 Boundaries can be styled via tags

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -48,6 +48,8 @@ rectangle C4VersionDetailsArea <<legendArea>> [
 !global $LEGEND_DOTTED_LINE = "(dotted) "
 !global $LEGEND_DASHED_LINE = "(dashed) "
 !global $LEGEND_BOLD_LINE = "(bold) "
+!global $LEGEND_DASHED_BOUNDARY = "boundary (dashed) "
+!global $LEGEND_DASHED_TRANSPARENT_BOUNDARY = "boundary (dashed, transparent) "
 
 !global $SKETCH_FOOTER_WARNING = "Warning:"
 !global $SKETCH_FOOTER_TEXT = "Created for discussion, needs to be validated"
@@ -115,21 +117,19 @@ skinparam person {
 }
 
 ' Some boundary skinparams have to be set as package skinparams too (PlantUML uses internal packages)
+' UpdateBoundaryStyle() called in boundary section below
+skinparam rectangle<<boundary>> {
+    Shadowing false
+    StereotypeFontSize 6
+    StereotypeFontColor $BOUNDARY_BG_COLOR
+    BorderStyle dashed
+}
+
 skinparam package {
     StereotypeFontSize 6
     StereotypeFontColor $BOUNDARY_BG_COLOR
     FontStyle plain
     BackgroundColor $BOUNDARY_BG_COLOR
-}
-
-skinparam rectangle<<boundary>> {
-    Shadowing false
-    StereotypeFontSize 6
-    StereotypeFontColor $BOUNDARY_BG_COLOR
-    FontColor $BOUNDARY_COLOR
-    BorderColor $BOUNDARY_COLOR
-    BackgroundColor $BOUNDARY_BG_COLOR
-    BorderStyle dashed
 }
 
 ' Legend and Tags
@@ -265,7 +265,7 @@ skinparam rectangle<<boundary>> {
 !function $elementTagSkinparams($element, $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape)
   !$elementSkin = "skinparam " + $element + "<<" + $tagStereo + ">> {" + %newline()
   !if ($fontColor != "")
-    !if ($tagStereo != "boundary")
+    !if (%strpos($tagStereo, "boundary") < 0)
       !$elementSkin = $elementSkin + "    StereotypeFontColor " + $fontColor + %newline()
     !endif
     !$elementSkin = $elementSkin + "    FontColor " + $fontColor + %newline()
@@ -304,9 +304,9 @@ skinparam rectangle<<boundary>> {
   ' actor has style awesome, therefore $fontColor is ignored and text uses $bgColor too
   !$tagSkin = $tagSkin + $elementTagSkinparams("actor", $tagStereo, $bgColor, $bgColor, $borderColor, $shadowing, "")
   !$tagSkin = $tagSkin + $elementTagSkinparams("person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
-  !if ($tagStereo == "boundary" && $bgColor != "")
-    !$tagSkin = $tagSkin + "skinparam package<<boundary>>StereotypeFontColor " + $bgColor + %newline()
-    !$tagSkin = $tagSkin + "skinparam rectangle<<boundary>>StereotypeFontColor " + $bgColor + %newline()
+  !if (%strpos($tagStereo, "boundary") >= 0 && $bgColor != "")
+    !$tagSkin = $tagSkin + "skinparam package<<" + $tagStereo + ">>StereotypeFontColor " + $bgColor + %newline()
+    !$tagSkin = $tagSkin + "skinparam rectangle<<" + $tagStereo + ">>StereotypeFontColor " + $bgColor + %newline()
   !endif
 $tagSkin
 !endprocedure
@@ -499,7 +499,26 @@ $elementSkin
     !$tagEntry = $tagEntry + $getSprite($legendSprite) + " "
   !endif
   !if ($legendText == "")
-    !$tagEntry = $tagEntry + " " + $tagStereo + " "
+    !if ($tagStereo == "boundary")
+      !if ($bgColor == "#00000000" || %lower($bgColor) == "transparent")
+        !$tagEntry = $tagEntry + " " + $LEGEND_DASHED_TRANSPARENT_BOUNDARY
+      !else
+        !$tagEntry = $tagEntry + " " + $LEGEND_DASHED_BOUNDARY
+      !endif
+    !elseif (%strpos($tagStereo, "boundary") >= 0)
+      ' if contains/ends with _boundary remove _boundary and add "boundary (dashed)"
+      !$pos = %strpos($tagStereo, "_boundary")
+      !if ($pos > 0)
+        !$tagEntry = $tagEntry + " " + %substr($tagStereo, 0 ,$pos)
+        !if ($bgColor == "#00000000" || %lower($bgColor) == "transparent")
+          !$tagEntry = $tagEntry + " " + $LEGEND_DASHED_TRANSPARENT_BOUNDARY
+        !else
+          !$tagEntry = $tagEntry + " " + $LEGEND_DASHED_BOUNDARY
+        !endif
+      !endif
+    !else
+      !$tagEntry = $tagEntry + " " + $tagStereo + " "
+    !endif
     !if ($shadowing == "true")
       !$tagEntry = $tagEntry + $LEGEND_SHADOW_TEXT
     !endif
@@ -1032,6 +1051,43 @@ $getLegendArea($alias, $hideStereotype)
 ' Boundaries
 ' ##################################
 
+!unquoted procedure UpdateBoundaryStyle($elementName="", $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $type="", $legendText="")
+  !if ($elementName != "")
+    !$elementBoundary = $elementName + '_boundary'
+    UpdateElementStyle($elementBoundary, $bgColor, $fontColor, $borderColor, $shadowing, $shape, "", $type, $legendText, "")
+  !else
+    UpdateElementStyle("boundary", $bgColor, $fontColor, $borderColor, $shadowing, $shape, "", $type, $legendText, "")
+    ' simulate color inheritance
+    UpdateBoundaryStyle("enterprise", $bgColor, $fontColor, $borderColor, $shadowing, $shape, "Enterprise", "")
+    UpdateBoundaryStyle("system", $bgColor, $fontColor, $borderColor, $shadowing, $shape, "System", "")
+    UpdateBoundaryStyle("container", $bgColor, $fontColor, $borderColor, $shadowing, $shape, "Container", "")
+  !endif
+!endprocedure
+
+!unquoted procedure AddBoundaryTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $type="", $legendText="")
+    !$tagBoundary = $tagStereo + '_boundary'
+    AddElementTag($tagBoundary, $bgColor, $fontColor, $borderColor, $shadowing, $shape, "", $type, $legendText, "")
+!endprocedure
+
+' add _boundary to all tags that short tag version can be used
+!unquoted function $addBoundaryPostfix($tags)
+  !if (%strlen($tags) == 0)
+    !return ''
+  !endif
+  !$boundaryTags = ''
+  !$brPos = %strpos($tags, "+")
+  !while ($brPos >= 0)
+    !$tag = %substr($tags, 0, $brPos)
+    !$boundaryTags = $boundaryTags + $tag + '_boundary+'
+    !$tags = %substr($tags, $brPos+1)
+    !$brPos = %strpos($tags, "+")
+  !endwhile
+  !if (%strlen($tags) > 0)
+    !$boundaryTags = $boundaryTags + $tags + '_boundary'
+  !endif
+  !return $boundaryTags
+!endfunction
+
 !function $getBoundary($label, $type)
   !if ($type == "")
     !return '==' + $label
@@ -1042,8 +1098,14 @@ $getLegendArea($alias, $hideStereotype)
 !endfunction
 
 !unquoted procedure Boundary($alias, $label, $type="", $tags="", $link="")
-rectangle "$getBoundary($label, $type)" $toStereos("boundary", $tags) as $alias $getLink($link)
+!$boundaryTags = $addBoundaryPostfix($tags)
+' nodes $type reuses $techn definition of $boundaryTags
+!$type=$toElementArg($type, $boundaryTags, "ElementTagTechn", "boundary")
+rectangle "$getBoundary($label, $type)" $toStereos("boundary", $boundaryTags) as $alias $getLink($link)
 !endprocedure
+
+' Boundary Styling
+UpdateBoundaryStyle("", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR)
 
 ' Relationship
 ' ##################################

--- a/C4_Component.puml
+++ b/C4_Component.puml
@@ -37,7 +37,7 @@ UpdateElementStyle("external_component", $EXTERNAL_COMPONENT_BG_COLOR, $COMPONEN
 ' Layout
 ' ##################################
 
-SetDefaultLegendEntries("person\nsystem\ncontainer\ncomponent\nexternal_person\nexternal_system\nexternal_container\nexternal_component")
+SetDefaultLegendEntries("person\nsystem\ncontainer\ncomponent\nexternal_person\nexternal_system\nexternal_container\nexternal_component\nenterprise_boundary\nsystem_boundary\ncontainer_boundary\nboundary")
 
 !procedure LAYOUT_WITH_LEGEND()
 hide stereotype

--- a/C4_Container.puml
+++ b/C4_Container.puml
@@ -23,6 +23,8 @@
 UpdateElementStyle("container", $CONTAINER_BG_COLOR, $ELEMENT_FONT_COLOR, $CONTAINER_BORDER_COLOR)
 UpdateElementStyle("external_container", $EXTERNAL_CONTAINER_BG_COLOR, $ELEMENT_FONT_COLOR, $EXTERNAL_CONTAINER_BORDER_COLOR)
 
+UpdateBoundaryStyle("container", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $type="Container")
+
 ' shortcuts with default colors
 !unquoted procedure AddContainerTag($tagStereo, $bgColor=$CONTAINER_BG_COLOR, $fontColor=$ELEMENT_FONT_COLOR, $borderColor=$CONTAINER_BORDER_COLOR, $shadowing="", $shape="", $sprite="", $techn="", $legendText="", $legendSprite="")
   AddElementTag($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $techn, $legendText, $legendSprite)
@@ -31,10 +33,14 @@ UpdateElementStyle("external_container", $EXTERNAL_CONTAINER_BG_COLOR, $ELEMENT_
   AddElementTag($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $techn, $legendText, $legendSprite)
 !endprocedure
 
+!unquoted procedure UpdateContainerBoundaryStyle($bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $shadowing="", $shape="", $type="Container", $legendText="")
+  UpdateBoundaryStyle("container", $bgColor, $fontColor, $borderColor, $shadowing, $shape, $type, $legendText)
+!endprocedure
+
 ' Layout
 ' ##################################
 
-SetDefaultLegendEntries("person\nsystem\ncontainer\nexternal_person\nexternal_system\nexternal_container")
+SetDefaultLegendEntries("person\nsystem\ncontainer\nexternal_person\nexternal_system\nexternal_container\nenterprise_boundary\nsystem_boundary\ncontainer_boundary\nboundary")
 
 !procedure LAYOUT_WITH_LEGEND()
 hide stereotype
@@ -107,5 +113,11 @@ queue "$getContainer($label, $techn, $descr, $sprite)$getProps()" $toStereos("ex
 ' ##################################
 
 !unquoted procedure Container_Boundary($alias, $label, $tags="", $link="")
-Boundary($alias, $label, "Container", $tags, $link)
+  !if ($tags != "")
+    !$allTags = $tags + '+container'
+  !else
+    !$allTags = 'container'
+  !endif
+  ' $type defined via $tag style
+  Boundary($alias, $label, "", $allTags, $link)
 !endprocedure

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -30,6 +30,9 @@ UpdateElementStyle("external_person", $EXTERNAL_PERSON_BG_COLOR, $ELEMENT_FONT_C
 UpdateElementStyle("system", $SYSTEM_BG_COLOR, $ELEMENT_FONT_COLOR, $SYSTEM_BORDER_COLOR)
 UpdateElementStyle("external_system", $EXTERNAL_SYSTEM_BG_COLOR, $ELEMENT_FONT_COLOR, $EXTERNAL_SYSTEM_BORDER_COLOR)
 
+UpdateBoundaryStyle("enterprise", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $type="Enterprise")
+UpdateBoundaryStyle("system", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $type="System")
+
 ' shortcuts with default colors
 !unquoted procedure AddPersonTag($tagStereo, $bgColor=$PERSON_BG_COLOR, $fontColor=$ELEMENT_FONT_COLOR, $borderColor=$PERSON_BORDER_COLOR, $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
   AddElementTag($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
@@ -42,6 +45,13 @@ UpdateElementStyle("external_system", $EXTERNAL_SYSTEM_BG_COLOR, $ELEMENT_FONT_C
 !endprocedure
 !unquoted procedure AddExternalSystemTag($tagStereo, $bgColor=$EXTERNAL_SYSTEM_BG_COLOR, $fontColor=$ELEMENT_FONT_COLOR, $borderColor=$EXTERNAL_SYSTEM_BORDER_COLOR, $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
   AddElementTag($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
+!endprocedure
+
+!unquoted procedure UpdateEnterpriseBoundaryStyle($bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $shadowing="", $shape="", $type="Enterprise", $legendText="")
+  UpdateBoundaryStyle("enterprise", $bgColor, $fontColor, $borderColor, $shadowing, $shape, $type, $legendText)
+!endprocedure
+!unquoted procedure UpdateSystemBoundaryStyle($bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $shadowing="", $shape="", $type="System", $legendText="")
+  UpdateBoundaryStyle("system", $bgColor, $fontColor, $borderColor, $shadowing, $shape, $type, $legendText)
 !endprocedure
 
 ' Sprites
@@ -152,7 +162,7 @@ sprite $person2 [48x48/16] {
 ' Layout
 ' ##################################
 
-SetDefaultLegendEntries("person\nsystem\nexternal_person\nexternal_system")
+SetDefaultLegendEntries("person\nsystem\nexternal_person\nexternal_system\nenterprise_boundary\nsystem_boundary\nboundary")
 
 !procedure LAYOUT_WITH_LEGEND()
 hide stereotype
@@ -284,9 +294,21 @@ queue "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_syst
 ' ##################################
 
 !unquoted procedure Enterprise_Boundary($alias, $label, $tags="", $link="")
-Boundary($alias, $label, "Enterprise", $tags, $link)
+  !if ($tags != "")
+    !$allTags = $tags + '+enterprise'
+  !else
+    !$allTags = 'enterprise'
+  !endif
+  ' $type defined via $tag style
+  Boundary($alias, $label, "", $allTags, $link)
 !endprocedure
 
 !unquoted procedure System_Boundary($alias, $label, $tags="", $link="")
-Boundary($alias, $label, "System", $tags, $link)
+  !if ($tags != "")
+    !$allTags = $tags + '+system'
+  !else
+    !$allTags = 'system'
+  !endif
+  ' $type defined via $tag style
+  Boundary($alias, $label, "", $allTags, $link)
 !endprocedure

--- a/C4_Deployment.puml
+++ b/C4_Deployment.puml
@@ -30,7 +30,7 @@ skinparam rectangle<<node>> {
 ' ##################################
 
 ' comment if node should not be added to legend. No calculated legend extension required
-SetDefaultLegendEntries("person\nsystem\ncontainer\nexternal_person\nexternal_system\nexternal_container\nnode")
+SetDefaultLegendEntries("person\nsystem\ncontainer\nexternal_person\nexternal_system\nexternal_container\nnode\nenterprise_boundary\nsystem_boundary\ncontainer_boundary\nboundary")
 
 ' Line breaks
 ' ##################################

--- a/README.md
+++ b/README.md
@@ -462,10 +462,15 @@ Additional tags/stereotypes can be added to the existing element stereotypes (co
   Introduces a new element tag. The styles of the tagged elements are updated and the tag is displayed in the calculated legend.
 * `AddRelTag(tagStereo, ?textColor, ?lineColor, ?lineStyle, ?sprite, ?techn, ?legendText, ?legendSprite)`:
   Introduces a new Relationship tag. The styles of the tagged relationships are updated and the tag is displayed in the calculated legend.
+* `AddBoundaryTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`:
+  Introduces a new Boundary tag. The styles of the tagged boundaries are updated and the tag is displayed in the calculated legend.
 * `UpdateElementStyle(elementName, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`:
   This call updates the default style of the elements (component, ...) and creates no additional legend entry.
 * `UpdateRelStyle(textColor, lineColor)`:
   This call updates the default relationship colors and creates no additional legend entry.
+* `UpdateBoundaryStyle(?elementName, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)
+  This call updates the default style of the existing boundaries and creates no additional legend entry.
+  If the element name is "" then it updates generic, enterprise, system and container boundary style in on call.
 * `RoundedBoxShape()`: This call returns the name of the rounded box shape and can be used as ?shape argument.
 * `EightSidedShape()`: This call returns the name of the eight sided shape and can be used as ?shape argument.
 * `DashedLine()`: This call returns the name of the dashed line and can be used as ?lineStyle argument.
@@ -497,6 +502,13 @@ Following calls introduces new element tags with element specific default colors
 * `AddExternalContainerTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?techn, ?sprite, ?legendText, ?legendSprite)`
 * `AddNodeTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`
   (node specific: $type reuses $techn definition of $tags)
+
+**Boundary specific tag definitions**
+
+Like the element specific tag definitions exist boundary specific calls with their default colors **and type**:
+* `UpdateContainerBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`
+* `UpdateSystemBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`
+* `UpdateEnterpriseBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`
 
 **Comments**
 
@@ -615,6 +627,55 @@ SHOW_LEGEND()
 ```
 
 ![tags with sprites and custom legend](https://www.plantuml.com/plantuml/png/dLJTRkCs4xttKt2DlN00nyewNxu0HRDOnqwxNJYRr3_DfJ0Inx9QYbH9AevHzDqxf6tHiPMVDbSHvvmpXpE7_c8iQ5iLelKXbwceEBAbjQNv8Oeqh7fPRfTLKXdKgP8MfUsbgeXA0T9nJetb8a-YuVzExztH_7OS5M0iQZgAXyI0NABkbKw_zO7ZWZwPCd1F1-_eCzHWbiYBNF9er-1KbIWDffNExHfqkimjfhRIs3_DYMks1i9rjksYeIeA9RsNu-BSa6SGObCEzH_LOf6d64rHFw8s4GSB2HYCZJ_u_39oaOjteA0iHPw2pPLy6Ko3JB6q9d88EeZtMA_15xd65GZnkTKQS7xpP55B4FVKLyaPP9qsI2NNXQfCZ4-stMKVJKbJnQksCX2xPSI9WFIFU0c-AZ13oMU4lGfKvd3j4zTXJpcjZ5K5waPH0Jh3EDEgAezaiqnZ1XPviowuC3IAGiLpsqsLKFfA8m_2qsQaIK7WrLclVn58HsvSjznOxKUzS-GirTdshbQO3CfotzRnNW-rYSC8nTAT4YaV2VDaNpI4hq4nb5-NTBaq-whke5dHbzYczBee5Gy6q13LGtKY6INmQ0fEVeB22-yYxBYMM4E_glR7mMHozn0FxyPt4ozBrAPIC5GhrOi_Vsdl0UlCRC8Nq-lfr9dtEUgozhLAl378pDN1OphP4ZiXqJlM58ek--LHIGpa-hq4thFirHrHInve7kHSJjV6OX5VgqfoqEjE-ed05jEbrNc2flUxQP_yrMBqLo-kGmbqwo7W0sLny6nHxM_m25tctexCsErlmowRgOBAxBBt5FflWt_oN7cKT3IAc2UaGulqcY3OQ9jF9t-xdluwPXUzYtqrdXmgTNnQ_Ts8z9EBu-QcRVSvc9tt0zj36wn8PVuK1F-kN4jdWasjqXiRIcPgTCtwlVuRHggIW_Khc6_-sms9NJgK3x8RHTYeaflH_DrgqH2EmXEcFpTedDhNsUn-6WH223q_vEY_2Xm6wj-AU9MQiBTXu8Ojj2eOICvMxhaPPfKJeub7tqRNb9vIQSlEpy_-lt4JTCA6dsaTmdPR38Zz_Qt89IkriYfLOjkiVtdswN9hEvw71RvXd53mbliWT-3_eRxy4IvSe7bSxxxE6DRnf7vWeJsLfb_fbszyy_FDzr7dfFK59QyAyGy0 "tags with sprites and custom legend")
+
+**Sample with different boundary tag combinations**
+
+```plantuml
+@startuml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+' Update the generic boundary style and the "system", "enterprise", "container" boundaries styles too
+UpdateBoundaryStyle($bgColor="gold", $fontColor="brown", $borderColor="brown")
+' (Re-)Updates the system boundary styles; re-set $bgColor avoids '(no back color)' in legend too
+UpdateSystemBoundaryStyle($bgColor="gold", $fontColor="white", $borderColor="white")
+
+Boundary(b, "A Boundary") {
+}
+
+Container_Boundary(cb, "A Container Boundary") {
+}
+
+System_Boundary(sb, "A System Boundary") {
+}
+
+' defines a new border style incl. new border type
+AddBoundaryTag("repository", $bgColor="green", $fontColor="white", $borderColor="white", $shadowing="true", $shape = RoundedBoxShape(), $type="GitHub repository")
+
+Boundary(c4Respository, "plantuml-stdlib/C4-PlantUML", $tags="repository") {
+  Component(readMe, "README.md", "Markdown")
+}
+
+' boundary tags are internally extended with '_boundary' that it uses a different name space
+' this enables different element and boundary styles for the same tag name
+AddBoundaryTag("v1", $bgColor="lightgreen", $fontColor="green", $borderColor="green")
+AddElementTag("v1", $bgColor="lightred", $fontColor="red", $borderColor="red")
+
+Boundary(anotherBoundary, "Another Boundary", $type="BOUNDARY TYPE", $tags="v1") {
+  Component(anotherComponent, "Another Component", $techn="COMPONENT TYPE", $tags="v1", $descr="Component and boundary use different tag name spaces that both v1 tags can use different styles")
+}
+
+Lay_R(b, cb)
+Lay_R(cb, sb)
+
+Lay_D(b, c4Respository)
+
+Lay_R(c4Respository, anotherBoundary)
+
+SHOW_LEGEND()
+@enduml
+```
+
+![custom border tags](https://www.plantuml.com/plantuml/png/bLHHRzem47xFhxX5bKYa0ghKfqr8fO3QXm8Lj9hwX9puIAmcTcGxfMZQVvyF4vg6RTgUsllkxlEN--wuCPPfMvT5y4N8jAWvGcvjPRuEXvhj1fcmUPtK1dMgf4Lf1wagXrN19FNqZUM5I8QJw_uZGS_pXs79Z4NjeCr4bPMIr5CHVz23vuepYs1pX0mbQf52ech9cTw3iVi2WKb-I8TcxsZAy192Hu2wqi8WHII32TSRDgq2ZMysO9KA_1ktHzer9QAB99keGkbHcAc2EvgBhQCvGebMEqbOeZH7_GcDdUXeXVtOivg3DY-jezny0urzWnQQnu2zAS4Dz2Af867fAwG4npqG4WhCKFAMuFM1z3zaxt9XiIExGUCWQ9YYn0rj34qOnl0Z-1a4asQCcrDXwYjFcRCUB_6ZmVW63vzLzu3Zrl4OO21n1rxcqMPQjK4RjliAWp7d3SiJow9GOwMCiCgHNa9h61fH_liq23KvusedP3OAhQuRg48OmOfUHFVm-vgGA7OvKZCAxuIzhnDegMZFDRrUeMaoRX1_kOcGA5bcHkqleZ41d6uaqiZu71tHQZQUpcU3aWmFvqo_Sh-9DDEFfIC-O9f6QL5BLXHxm7UBz2sm4pQ7tgOfxe7DcGLXeJO7FxZORb6Zj21PYM0gbc90LS80IfOKQ5erM619VvdatQM7hTB-9eZ7QIB2SoFVhZuPM8WijxzpqMDT5pqQ4-lCI_aZgSRkcH3I9IIiRIMJokQecvYscf3s2PoMudRvl9YELo_mzF8uEnbBOZg6Dgmde4LxmWu4cEPo54wMyyVbOhPuEcEc_pcQr2dtZLqpoDQMNwwlvQlnvYVkPNYxydkJCjdfyNRwBNjW-ysAVZVI93u6gOkCYmxXz91hht_SD7MEeZDOLxQ-NtxVFCpkPejf50StABaxcLy0 "custom border tags")
 
 **Custom schema definition**
 

--- a/percy/TestBoundaryTagSupport.puml
+++ b/percy/TestBoundaryTagSupport.puml
@@ -1,0 +1,49 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include ./../C4_Component.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+!endif
+
+UpdateBoundaryStyle($bgColor="gold", $fontColor="brown", $borderColor="brown")
+' re-set $bgColor avoids '(no back color)' in legend
+UpdateSystemBoundaryStyle($bgColor="gold", $fontColor="white", $borderColor="white")
+
+AddBoundaryTag("specialSystem", $bgColor="green", $fontColor="white", $borderColor="blue", $shadowing="true", $shape = RoundedBoxShape(), $type="A SPECIAL SYSTEM BOUNDARY")
+AddBoundaryTag("existingContainersBoundary", $bgColor="red", $fontColor="white", $borderColor="white", $type="Existing CONTAINER BOUNDARY", $legendText="container boundary with existing components")
+
+System_Boundary(sb, "A System Boundary") {
+}
+
+System_Boundary(sb1, "Special System 1 Boundary", $tags="specialSystem") {
+  Container_Boundary(cb1, "Container Boundary\nwith tag", $tags="existingContainersBoundary") {
+    Component(e1, "existing 1", "xyz")
+    Component(e2, "existing 2", "xyz")
+  }
+  Container_Boundary(cb2, "A Container Boundary") {
+    Component(c2, "Component", "xyz")
+  }
+}
+
+System_Boundary(sb2, "Special System 2 Boundary", $tags="specialSystem") { 
+}
+
+' boundary tags are internally extended with '_boundary' that it uses a different name space
+' this enables different element and boundary styles for the same tag name
+AddBoundaryTag("v1", $bgColor="lightgreen", $fontColor="green", $borderColor="green")
+AddElementTag("v1", $bgColor="lightred", $fontColor="red", $borderColor="red")
+
+Boundary(anotherBoundary, "Another Boundary", $type="BOUNDARY TYPE", $tags="v1") {
+  Component(anotherComponent, "Another Component", $techn="COMPONENT TYPE", $tags="v1", $descr="Component and boundary use different tag name spaces that both v1 tags can use different styles")
+}
+
+Boundary(aBoundary, "A Boundary") {
+}
+
+Lay_R(sb, sb1)
+Lay_R(sb1, sb2)
+Lay_R(sb2, anotherBoundary)
+
+SHOW_LEGEND()
+@enduml


### PR DESCRIPTION
implementation of #227

With following calls is it possible to update existing boundary styles or add new boundary tags, which can then be used in combination with the boundaries. (There was already a tag support but now it has a better legend support and it has its own tag namespace that elements and boundaries can have different style for the same tag name)

* `AddBoundaryTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`:
  Introduces a new Boundary tag. The styles of the tagged boundaries are updated and the tag is displayed in the calculated legend.
* `UpdateBoundaryStyle(?elementName, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`:
  This call updates the default style of the existing boundaries and creates no additional legend entry.
  If the element name is "" then it updates generic, enterprise, system and container boundary style in on call.

**Boundary specific tag definitions**

Like the element specific tag definitions exist boundary specific calls with their default colors **and type**:
* `UpdateContainerBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`
* `UpdateSystemBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`
* `UpdateEnterpriseBoundaryStyle(?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`

The calls can be used like 

**Sample with different boundary tag combinations**

```plantuml
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Component.puml

' Update the generic boundary style and the "system", "enterprise", "container" boundaries styles too
UpdateBoundaryStyle($bgColor="gold", $fontColor="brown", $borderColor="brown")
' (Re-)Updates the system boundary styles; re-set $bgColor avoids '(no back color)' in legend too
UpdateSystemBoundaryStyle($bgColor="gold", $fontColor="white", $borderColor="white")

Boundary(b, "A Boundary") {
}

Container_Boundary(cb, "A Container Boundary") {
}

System_Boundary(sb, "A System Boundary") {
}

' defines a new border style incl. new border type
AddBoundaryTag("repository", $bgColor="green", $fontColor="white", $borderColor="white", $shadowing="true", $shape = RoundedBoxShape(), $type="GitHub repository")

Boundary(c4Respository, "plantuml-stdlib/C4-PlantUML", $tags="repository") {
  Component(readMe, "README.md", "Markdown")
}

' boundary tags are internally extended with '_boundary' that it uses a different name space
' this enables different element and boundary styles for the same tag name
AddBoundaryTag("v1", $bgColor="lightgreen", $fontColor="green", $borderColor="green")
AddElementTag("v1", $bgColor="lightred", $fontColor="red", $borderColor="red")

Boundary(anotherBoundary, "Another Boundary", $type="BOUNDARY TYPE", $tags="v1") {
  Component(anotherComponent, "Another Component", $techn="COMPONENT TYPE", $tags="v1", $descr="Component and boundary use different tag name spaces that both v1 tags can use different styles")
}

Lay_R(b, cb)
Lay_R(cb, sb)

Lay_D(b, c4Respository)

Lay_R(c4Respository, anotherBoundary)

SHOW_LEGEND()
@enduml
```

![](https://www.plantuml.com/plantuml/png/bLH1R_8u4BtdLyn6bKYa0ghKqwwGIW6rXm8Lj5hrX1nxIAm6ExATKhJQ__vvCA5f-Bv3Jp1lPfuVysQuiuuPL-_Aw2-fU5aBXCAvoluz71gs7-JI5NLMMpHSAuVA3RZU3T-buOLrnN1ostykcNAlywSXVlgyGE71pKJlAgsel2Bgg0UlbM0EmHK8EIeqaaEcQoMOEO1rXnA1AN5Cn_PW7UxYQuWz0PhAI8iKaG8cVM_Sj4gqeTc2qpeARzoVQDUKIAwoVA9BRKPnhalXQQwsdkO4PKRl5M6PDWBDDpJrefCLzjF0Qe_QWhIESliF6EnRTD0y1kn3Is6XboWD6UFlm0bEUo0Lb9YZ4Yt1woFf3sJl2-cm8xj1qoXgc9BC3sqCJHYdy5_qVnHDcZ5kpeKyL9up5pr1ubU33Gq1lgZkWS2jvx70GE4UWioJpRHbWpRi3XL6Oo4QbXUM9x71Iblfj2UzXjOm3ABwmJGyQWicz5wgV1GxKpTGXJ225Rs8_k7FDI59wdEaPXG_IFTOPz1IqPuhlrsXRJ9-45N959rGtpfHognz5J5HijoEsh-8nWHmlf7481Dpz4IhsNWwdmrsP7WyP-PTX4sacNuj7V41CpHAXqQniZn0Stombww0tgOfxe4hc0FfeBP7FuJSRj6WSg3O3i5MZ6D4LT82AfQLQ5irMEAEFfaItQM7hJRX9ZmFQIB2IoC_RhuPMCgySBzpCM1T5mEQ4kiiIFaZgS7kcH3I9IIiRILJsXLecfYscf3s2PoNudxvkfYELs_mylOyEnjBOZg6Dgnde4Lxneu4o0irYYVB-VDoCLkyN33JTu6MU-MXiMi6sThoo_UrVBN1_Co_31ytOMyuKvsUO6VOiYTssApeVuDdwIdWFh8-EePJodrR_xHfwXn5Px2-RFsu_7VpD7kOBQP96jsX4lvaVW40)

It can be tested with [my extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended)

BR Helmut