### PR TITLE
Change percy workflow to use @percy/cli.

### DIFF
--- a/.github/workflows/run-percy-tests.yml
+++ b/.github/workflows/run-percy-tests.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           args: '-v percy -o _parsed -DRELATIVE_INCLUDE="."'
       - name: Upload
-        run: npx percy upload percy/_parsed
+        run: npx @percy/cli upload percy/_parsed
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
Currently, the build is broken. This has to do with Percy migrating to a new package structure.

In order to fix the build, instead of using `percy`, `@percy/cli` needs to be used.

This MR does that.