### PR TITLE
Add support for lineThickness in AddRelTag (based on #218, #235)

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -339,19 +339,21 @@ $tagSkin
 
 !unquoted procedure $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness)
   !$elementSkin = "skinparam arrow<<" + $tagStereo + ">> {" + %newline()
-  !$elementSkin = $elementSkin + "    Color "
-  !if ($lineColor != "")
-    !$elementSkin = $elementSkin + $colorWithoutHash($lineColor)
+  !if ($lineColor != "") || ($textColor != "") || ($lineStyle != "")
+    !$elementSkin = $elementSkin + "    Color "
+    !if ($lineColor != "")
+      !$elementSkin = $elementSkin + $colorWithoutHash($lineColor)
+    !endif
+    !if ($textColor != "")
+      !$elementSkin = $elementSkin + ";text:" + $colorWithoutHash($textColor)
+    !endif
+    !if ($lineStyle != "")
+      !$elementSkin = $elementSkin + ";line." + $lineStyle
+    !endif
+    !$elementSkin = $elementSkin + %newline()
   !endif
-  !if ($textColor != "")
-    !$elementSkin = $elementSkin + ";text:" + $colorWithoutHash($textColor)
-  !endif
-  !if ($lineStyle != "")
-    !$elementSkin = $elementSkin + ";line." + $lineStyle
-  !endif
-  !$elementSkin = $elementSkin + %newline()
   !if ($lineThickness != "")
-    !$elementSkin = $elementSkin + " thickness " + $lineThickness + %newline()
+    !$elementSkin = $elementSkin + "    thickness " + $lineThickness + %newline()
   !endif
   !$elementSkin = $elementSkin + "}" + %newline()
 $elementSkin

--- a/C4.puml
+++ b/C4.puml
@@ -337,7 +337,7 @@ $tagSkin
   !return $c
 !endfunction
 
-!unquoted procedure $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle)
+!unquoted procedure $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness)
   !$elementSkin = "skinparam arrow<<" + $tagStereo + ">> {" + %newline()
   !$elementSkin = $elementSkin + "    Color "
   !if ($lineColor != "")
@@ -350,6 +350,9 @@ $tagSkin
     !$elementSkin = $elementSkin + ";line." + $lineStyle
   !endif
   !$elementSkin = $elementSkin + %newline()
+  !if ($lineThickness != "")
+    !$elementSkin = $elementSkin + "    Thickness " + $lineThickness + %newline()
+  !endif
   !$elementSkin = $elementSkin + "}" + %newline()
 $elementSkin
 !endprocedure
@@ -568,7 +571,7 @@ $elementSkin
   !return $tagEntry
 !endfunction
 
-!function $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite)
+!function $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
   !$tc = $textColor
   !$lc = $lineColor
 
@@ -613,6 +616,9 @@ $elementSkin
         !$tagEntry = $tagEntry + "(" + $lineStyle + ") "
       !endif
     !endif
+    !if ($lineThickness != "")
+      !$tagEntry = $tagEntry + "(thickness " + $lineThickness + ") "
+    !endif
   !else
     !$tagEntry = $tagEntry + " " + $legendText + " "
   !endif
@@ -639,7 +645,7 @@ $elementSkin
 '  !endif
 !endprocedure
 
-!unquoted procedure $addRelTagToLegend($tagStereo, $textColor="", $lineColor="", $lineStyle="", $legendText="", $legendSprite="")
+!unquoted procedure $addRelTagToLegend($tagStereo, $textColor="", $lineColor="", $lineStyle="", $lineThickness, $legendText="", $legendSprite="")
 '' Arrows have a bug with stereotype/skinparams and cannot combine text colors of one stereotype
 '' and the line color of another stereotype. Therefore the text color of one tag and the line color
 '' of another tag have to be combined via a "workaround" tag ("v1.0&v1.1").
@@ -647,7 +653,7 @@ $elementSkin
 '' be an inconsistency between the element tags and the rel tags and therefore
 '' & combined workaround tags are not removed too (and in unlikely cases the color itself could be changed)
 '  !if (%strpos($tagStereo, "&") < 0)
-    !$tagEntry = $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite)
+    !$tagEntry = $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
 %set_variable_value("$" + $tagStereo + "_LineLegendEntry", $tagEntry)
     !$tagCustomLegend = $tagCustomLegend + $tagStereo + "_Line\n"
 '  !endif
@@ -721,8 +727,8 @@ $addTagToLegend($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $sha
 !endprocedure
 
 ' used by new defined rel tags
-!unquoted procedure AddRelTag($tagStereo, $textColor="", $lineColor="", $lineStyle = "", $sprite="", $techn="", $legendText="", $legendSprite="")
-$defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle)
+!unquoted procedure AddRelTag($tagStereo, $textColor="", $lineColor="", $lineStyle="", $lineThickness="", $sprite="", $techn="", $legendText="", $legendSprite="")
+$defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness)
   !if ($sprite != "")
 %set_variable_value("$" + $tagStereo + "RelTagSprite", $sprite)
     !if ($legendSprite == "")
@@ -733,7 +739,7 @@ $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle)
   !if ($techn != "")
 %set_variable_value("$" + $tagStereo + "RelTagTechn", $techn)
   !endif
-$addRelTagToLegend($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite)
+$addRelTagToLegend($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
 !endprocedure
 
 ' update the style of existing elements like person, ...

--- a/C4.puml
+++ b/C4.puml
@@ -351,7 +351,7 @@ $tagSkin
   !endif
   !$elementSkin = $elementSkin + %newline()
   !if ($lineThickness != "")
-    !$elementSkin = $elementSkin + "    Thickness " + $lineThickness + %newline()
+    !$elementSkin = $elementSkin + " thickness " + $lineThickness + %newline()
   !endif
   !$elementSkin = $elementSkin + "}" + %newline()
 $elementSkin
@@ -571,7 +571,7 @@ $elementSkin
   !return $tagEntry
 !endfunction
 
-!function $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
+!function $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite, $lineThickness)
   !$tc = $textColor
   !$lc = $lineColor
 
@@ -645,7 +645,7 @@ $elementSkin
 '  !endif
 !endprocedure
 
-!unquoted procedure $addRelTagToLegend($tagStereo, $textColor="", $lineColor="", $lineStyle="", $lineThickness, $legendText="", $legendSprite="")
+!unquoted procedure $addRelTagToLegend($tagStereo, $textColor="", $lineColor="", $lineStyle="", $legendText="", $legendSprite="", $lineThickness="")
 '' Arrows have a bug with stereotype/skinparams and cannot combine text colors of one stereotype
 '' and the line color of another stereotype. Therefore the text color of one tag and the line color
 '' of another tag have to be combined via a "workaround" tag ("v1.0&v1.1").
@@ -653,7 +653,7 @@ $elementSkin
 '' be an inconsistency between the element tags and the rel tags and therefore
 '' & combined workaround tags are not removed too (and in unlikely cases the color itself could be changed)
 '  !if (%strpos($tagStereo, "&") < 0)
-    !$tagEntry = $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
+    !$tagEntry = $tagRelLegendEntry($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite, $lineThickness)
 %set_variable_value("$" + $tagStereo + "_LineLegendEntry", $tagEntry)
     !$tagCustomLegend = $tagCustomLegend + $tagStereo + "_Line\n"
 '  !endif
@@ -727,7 +727,7 @@ $addTagToLegend($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $sha
 !endprocedure
 
 ' used by new defined rel tags
-!unquoted procedure AddRelTag($tagStereo, $textColor="", $lineColor="", $lineStyle="", $lineThickness="", $sprite="", $techn="", $legendText="", $legendSprite="")
+!unquoted procedure AddRelTag($tagStereo, $textColor="", $lineColor="", $lineStyle="", $sprite="", $techn="", $legendText="", $legendSprite="", $lineThickness="")
 $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness)
   !if ($sprite != "")
 %set_variable_value("$" + $tagStereo + "RelTagSprite", $sprite)
@@ -739,7 +739,7 @@ $defineRelSkinparams($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickn
   !if ($techn != "")
 %set_variable_value("$" + $tagStereo + "RelTagTechn", $techn)
   !endif
-$addRelTagToLegend($tagStereo, $textColor, $lineColor, $lineStyle, $lineThickness, $legendText, $legendSprite)
+$addRelTagToLegend($tagStereo, $textColor, $lineColor, $lineStyle, $legendText, $legendSprite, $lineThickness)
 !endprocedure
 
 ' update the style of existing elements like person, ...

--- a/README.md
+++ b/README.md
@@ -557,9 +557,8 @@ Like the element specific tag definitions exist boundary specific calls with the
 * If 2 tags define the same skinparam, the first definition is used.
 * If specific skinparams have to be merged (e.g. 2 tags change the font color) an additional combined tag has to be defined. Use `&` as part of combined tag names.
 
-* (Obsolete, fixed in PlantUML >=v.1.2022.2)  
-  Colors of relationship tags cannot be automatically merged (PlantUML does not support it).
-  If one tag modifies the line color and the other the text color, an additional combined tag has to be defined and used.
+* Automatically merging colors of relationship tags is not supported in PlantUML before v.1.2022  
+  If an older version is used and one tag modifies the line color and the other the text color, an additional combined tag has to be defined and used.
 
 ### Sample with different tag combinations
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Additional tags/stereotypes can be added to the existing element stereotypes (co
 
 * `AddElementTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`:
   Introduces a new element tag. The styles of the tagged elements are updated and the tag is displayed in the calculated legend.
-* `AddRelTag(tagStereo, ?textColor, ?lineColor, ?lineStyle, ?sprite, ?techn, ?legendText, ?legendSprite)`:
+* `AddRelTag(tagStereo, ?textColor, ?lineColor, ?lineStyle, ?lineThickness, ?sprite, ?techn, ?legendText, ?legendSprite)`:
   Introduces a new Relationship tag. The styles of the tagged relationships are updated and the tag is displayed in the calculated legend.
 * `AddBoundaryTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`:
   Introduces a new Boundary tag. The styles of the tagged boundaries are updated and the tag is displayed in the calculated legend.

--- a/README.md
+++ b/README.md
@@ -549,15 +549,16 @@ Like the element specific tag definitions exist boundary specific calls with the
 
 ### Comments
 
-* `SHOW_LEGEND()` supports the customized stereotypes
-      (`LAYOUT_WITH_LEGEND()` cannot be used, if the custom tags/stereotypes should be displayed in the legend).
+* `SHOW_LEGEND()` supports the customized stereotypes  
+  (`LAYOUT_WITH_LEGEND()` cannot be used, if the custom tags/stereotypes should be displayed in the legend).
 * `SHOW_LEGEND()` has to be last line in diagram.
 * Don't use space between `$tags` and `=` (PlantUML does not support it).
 * Don't use `,` as part of the tag names (PlantUML does not support it in combination with keyword arguments).
 * If 2 tags define the same skinparam, the first definition is used.
 * If specific skinparams have to be merged (e.g. 2 tags change the font color) an additional combined tag has to be defined. Use `&` as part of combined tag names.
 
-* Colors of relationship tags cannot be automatically merged (PlantUML does not support it).
+* (Obsolete, fixed in PlantUML >=v.1.2022.2)  
+  Colors of relationship tags cannot be automatically merged (PlantUML does not support it).
   If one tag modifies the line color and the other the text color, an additional combined tag has to be defined and used.
 
 ### Sample with different tag combinations

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Additional tags/stereotypes can be added to the existing element stereotypes (co
 
 * `AddElementTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`:
   Introduces a new element tag. The styles of the tagged elements are updated and the tag is displayed in the calculated legend.
-* `AddRelTag(tagStereo, ?textColor, ?lineColor, ?lineStyle, ?lineThickness, ?sprite, ?techn, ?legendText, ?legendSprite)`:
+* `AddRelTag(tagStereo, ?textColor, ?lineColor, ?lineStyle, ?sprite, ?techn, ?legendText, ?legendSprite, ?lineThickness)`:
   Introduces a new Relationship tag. The styles of the tagged relationships are updated and the tag is displayed in the calculated legend.
 * `AddBoundaryTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?type, ?legendText)`:
   Introduces a new Boundary tag. The styles of the tagged boundaries are updated and the tag is displayed in the calculated legend.

--- a/percy/TestLegend.puml
+++ b/percy/TestLegend.puml
@@ -31,7 +31,8 @@ AddRelTag("line1", $lineColor="green", $textColor="blue")
 AddRelTag("line2", $lineColor="blue", $textColor="green")
 AddRelTag("line3", $textColor="orange")
 AddRelTag("line4", $lineColor="orange")
-' PlantUML cannot combine line styles, a combination has to be added as workaround as first additional tag
+' outdated: PlantUML cannot combine line styles, a combination has to be added as workaround as first additional tag
+' fixed in meantime
 AddRelTag("line3&line4", $lineColor="orange", $textColor="orange")
 AddRelTag("unusedLine", $lineColor="red", $textColor="red")
 
@@ -57,8 +58,8 @@ Rel(allInOne, component, "uses line 1", $tags="line1")
 Rel(allInOne, component, "uses line 2", $tags="line2")
 Rel(allInOne, system1A, "uses line 3", $tags="line3")
 Rel(allInOne, system1A, "uses line 4", $tags="line4")
-Rel(allInOne, system2, "line 3+4 cannot be combined without workaround", $tags="line3+line4")
-Rel(allInOne, system2, "line 3+4 with workaround", $tags="line3&line4+line3+line4")
+Rel(allInOne, system2, "line 3+4 (merge fixed in meantime)", $tags="line3+line4")
+Rel(allInOne, system2, "line 3+4 with workaround (obsolete in meantime)", $tags="line3&line4+line3+line4")
 
 SHOW_LEGEND(false)
 @enduml

--- a/percy/TestRelationsTags.puml
+++ b/percy/TestRelationsTags.puml
@@ -1,0 +1,43 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Component.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+!endif
+
+UpdateRelStyle(gray, gray)
+
+AddRelTag("textColorBlue", $textColor=blue)
+AddRelTag("textColorRed", $textColor="red")
+AddRelTag("lineColorBlue", $lineColor="blue")
+AddRelTag("lineStyleDashed", $lineStyle=DashedLine())
+AddRelTag("lineStyleDotted", $lineStyle=DottedLine())
+AddRelTag("lineStyleBold", $lineStyle=BoldLine())
+AddRelTag("lineThickness", $lineThickness=5)
+AddRelTag("bothSprites", $sprite="person2", $legendSprite="person2,scale=0.25")
+AddRelTag("technAndLegendText", $techn="HTTPS", $legendText="Another text in legend (incl. techn. https)")
+
+Person(person, "Person")
+
+System(system1, "System 1")
+System(system2, "System 2")
+System(system3, "System 3")
+System(system4, "System 3")
+
+Rel_U(person, system1, "without a tag")
+Rel_U(person, system1, "bothSprites", $tags="bothSprites")
+Rel_U(person, system1, "technAndLegendText", $tags="technAndLegendText")
+Rel_R(person, system2, "textColorBlue", $tags="textColorBlue")
+Rel_R(person, system2, "lineColorBlue", $tags="lineColorBlue")
+Rel_R(person, system2, "textColorRed+lineColorBlue", $tags="textColorRed+lineColorBlue")
+Rel_R(person, system2, "textColorRed+textColorBlue (first wins)", $tags="textColorRed+textColorBlue")
+Rel_D(person, system3, "lineStyleDashed", $tags="lineStyleDashed")
+Rel_D(person, system3, "lineStyleDotted", $tags="lineStyleDotted")
+Rel_D(person, system3, "lineStyleBold", $tags="lineStyleBold")
+Rel_D(person, system3, "lineStyleDotted+lineThickness", $tags="lineStyleDotted+lineThickness")
+Rel_L(person, system4, "textColorBlue+textColorRed+lineColorBlue+lineStyleDashed+lineThickness+bothSprites", $tags="textColorBlue+textColorRed+lineColorBlue+lineStyleDashed+lineThickness+bothSprites")
+Rel_L(person, system4, "textColorBlue+textColorRed+lineColorBlue+lineStyleDashed+lineThickness+bothSprites+technAndLegendText", $tags="textColorBlue+textColorRed+lineColorBlue+lineStyleDashed+lineThickness+bothSprites+technAndLegendText")
+
+SHOW_LEGEND()
+@enduml


### PR DESCRIPTION
based on PR #218 from @netrounds-fredrik  and PR #235 from @fredde-fisk. Thank you for your preparatory work.

`AddRelTag()` is extended with a new $lineThickness argument, like `AddRelTag("tag1", $lineThickness=3)`

```plantuml
@startuml
' !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Component.puml

AddRelTag("tag1", $lineThickness=3)
AddRelTag("tag2", $lineColor="darkblue", $lineStyle=DottedLine(), $lineThickness=8)

Container(a, "A")
Container(b, "B")
Container(c, "C")

Rel(a, c, "normal")
Rel(a, b, "thickness 3", $tags="tag1")
Rel(b, c, "blue, dotted, thickness 8", $tags="tag2")

SHOW_LEGEND()
@enduml
```

![](https://www.plantuml.com/plantuml/png/bOzDImCn48Rl-HLn4To5RHTR3qLOQDqMFTGFRCLZoIP3DpGVIp91_VScrg9LBnxdoJpll9bwP0w3LkICdaZ3LH10EyJUNrQLOo_3hSGkjC63uzOW61nogwjUCPEiWKUXP5ir5uE7X9vkbvLc7i55j6cixgr9Jfyk_2D_9ntlF7P7mV0QtmM8FwB9J8X7K6kspJDas_EifATA6bXtakyCU5-FYnyxeyDEOvLrTIQOsxKgm06ly4r1FRU889PnpejVcPE2a2QsPf6wd9KqcsN5Dz96SdL4U2HD92GMIKAQZNMQgGW_MRBmS8EEKvzOrzVxZ-tNshsQ-fPKV7GiwPSqEP96wU3gvlvvirnSB-xcUK6cO4JGwXq0)

It can be tested with [my extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended)

BR Helmut

PS.: during the tests with TestLegend.puml I saw that colors of relationships can be combined, therefore I updated the README.md and TestLegend.puml too

> * (Obsolete, fixed in PlantUML >=v.1.2022.2)  
>   Colors of relationship tags cannot be automatically merged (PlantUML does not support it).