### PR TITLE
#256 Person outline and portrait styles works with old plantuml.jar versions too

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -116,15 +116,15 @@ skinparam arrow {
     FontSize 12
 }
 
+skinparam person {
+    StereotypeFontSize 12
+    shadowing false
+}
+
 skinparam actor {
     StereotypeFontSize 12
     shadowing false
     style awesome
-}
-
-skinparam person {
-    StereotypeFontSize 12
-    shadowing false
 }
 
 ' Some boundary skinparams have to be set as package skinparams too (PlantUML uses internal packages)
@@ -330,9 +330,10 @@ skinparam package {
   !$tagSkin = $elementTagSkinparams("rectangle", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape)
   !$tagSkin = $tagSkin + $elementTagSkinparams("database", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   !$tagSkin = $tagSkin + $elementTagSkinparams("queue", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
+  ' plantuml.jar bug - actor have to be after person
+  !$tagSkin = $tagSkin + $elementTagSkinparams("person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   ' actor has style awesome, therefore $fontColor is ignored and text uses $bgColor too
   !$tagSkin = $tagSkin + $elementTagSkinparams("actor", $tagStereo, $bgColor, $bgColor, $borderColor, $shadowing, "")
-  !$tagSkin = $tagSkin + $elementTagSkinparams("person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   !if (%strpos($tagStereo, "boundary") >= 0 && $bgColor != "")
     !$tagSkin = $tagSkin + "skinparam package<<" + $tagStereo + ">>StereotypeFontColor " + $bgColor + %newline()
     !$tagSkin = $tagSkin + "skinparam rectangle<<" + $tagStereo + ">>StereotypeFontColor " + $bgColor + %newline()

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -281,6 +281,7 @@ endlegend
 !$dummy = $restoreEmpty("person", "sprite", $defaultPersonSprite, %true())
 UpdateElementStyle("person")
 ' workaround of plantuml.jar bug - person overwrites external_person setting
+!$dummy = $restoreEmpty("external_person", "sprite", $defaultPersonSprite, %true())
 UpdateElementStyle("external_person")
 !global $portraitPerson = "false"
 
@@ -290,6 +291,9 @@ UpdateElementStyle("external_person")
   %set_variable_value("$" + "person" + "ElementTagSprite", "")
   UpdateElementStyle("person")
   ' workaround of plantuml.jar bug - person overwrites external_person setting
+  !$dummy = $clearRestore("external_person", "sprite")
+  !$dummy = $clearRestore("external_person", "legendSprite")
+  %set_variable_value("$" + "external_person" + "ElementTagSprite", "")
   UpdateElementStyle("external_person")
 !endprocedure
 
@@ -308,6 +312,7 @@ UpdateElementStyle("external_person")
   !$dummy = $restoreEmpty("person", "sprite", $defaultPersonSprite, %true())
   UpdateElementStyle("person")
   ' workaround of plantuml.jar bug - person overwrites external_person setting
+  !$dummy = $restoreEmpty("external_person", "sprite", $defaultPersonSprite, %true())
   UpdateElementStyle("external_person")
   !$portraitPerson = "false"
 !endprocedure

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -280,6 +280,8 @@ endlegend
 !global $defaultPersonSprite = "person"
 !$dummy = $restoreEmpty("person", "sprite", $defaultPersonSprite, %true())
 UpdateElementStyle("person")
+' workaround of plantuml.jar bug - person overwrites external_person setting
+UpdateElementStyle("external_person")
 !global $portraitPerson = "false"
 
 !procedure $clearPersonRestore()
@@ -287,6 +289,8 @@ UpdateElementStyle("person")
   !$dummy = $clearRestore("person", "legendSprite")
   %set_variable_value("$" + "person" + "ElementTagSprite", "")
   UpdateElementStyle("person")
+  ' workaround of plantuml.jar bug - person overwrites external_person setting
+  UpdateElementStyle("external_person")
 !endprocedure
 
 !procedure HIDE_PERSON_SPRITE()
@@ -303,6 +307,8 @@ UpdateElementStyle("person")
   !endif
   !$dummy = $restoreEmpty("person", "sprite", $defaultPersonSprite, %true())
   UpdateElementStyle("person")
+  ' workaround of plantuml.jar bug - person overwrites external_person setting
+  UpdateElementStyle("external_person")
   !$portraitPerson = "false"
 !endprocedure
 


### PR DESCRIPTION
implement #256 old version plantuml.jar workaround (details see there)

following samples works now with older versions too

```plantuml
@startuml
!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml

Person_Ext(A, "Person A")

SHOW_LEGEND(true)
@enduml
```

```plantuml
@startuml
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Context.puml

UpdateElementStyle("person","orange","green","blue", $legendText="Person\ngreen label is only used in legend")
UpdateElementStyle("external_person","gold", "red", "darkred")

' SHOW_PERSON_OUTLINE()
SHOW_PERSON_PORTRAIT()

Person(p, "A person with orange label")
Person_Ext(extP, "An external person with gold label")

SHOW_LEGEND(false)
@enduml
```

@chriskn can you please test it with [my extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended) in your IntelliJ and AsciiDoc environment?

BR Helmut