### PR TITLE
Fix typo in bigbankplc-styles.puml Sample

### DIFF
--- a/percy/C4_Container Diagram Sample - bigbankplc-styles.puml
+++ b/percy/C4_Container Diagram Sample - bigbankplc-styles.puml
@@ -19,7 +19,7 @@ Person(customer, Customer, "A customer of the bank, with personal bank accounts"
 
 System_Boundary(c1, "Internet Banking") {
     Container(web_app, "Web Application", "Java, Spring MVC", "Delivers the static content and the Internet banking SPA")
-    Container(spa, "Single-Page App", "JavaScript, Angular", "Provides all the Internet banking functionality to cutomers via their web browser")
+    Container(spa, "Single-Page App", "JavaScript, Angular", "Provides all the Internet banking functionality to customers via their web browser")
     Container(mobile_app, "Mobile App", "C#, Xamarin", "Provides a limited subset of the Internet banking functionality to customers via their mobile device")
     ContainerDb(database, "Database", "SQL Database", "Stores user registration information, hashed auth credentials, access logs, etc.")
     Container(backend_api, "API Application", "Java, Docker Container", "Provides Internet banking functionality via API", $tags="backendContainer")


### PR DESCRIPTION
Fix `cutomer` typo as reported in #279