### PR TITLE
Add $techn argument to systems

### DIFF
--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -350,19 +350,19 @@ UpdateElementStyle("external_person")
 !endif
 !endfunction
 
-!function $getSystem($label, $descr, $sprite)
-!if ($descr == "") && ($sprite == "")
-!return '== '+$breakLabel($label)
-!endif
-!if ($descr == "") && ($sprite != "")
-!return $getSprite($sprite)+'\n== '+$breakLabel($label)
-!endif
-!if ($descr != "") && ($sprite == "")
-!return '== '+$breakLabel($label)+'\n\n '+$descr
-!endif
-!if ($descr != "") && ($sprite != "")
-!return $getSprite($sprite)+'\n== '+$breakLabel($label)+'\n\n '+$descr
-!endif
+!function $getSystem($label, $techn, $descr, $sprite)
+  !$system = ""
+  !if ($sprite != "")
+    !$system = $system + $getSprite($sprite) + '\n'
+  !endif
+  !$system = $system + '== ' + $breakLabel($label)
+  !if ($techn != "")
+    !$system = $system + '\n//<size:' + $TECHN_FONT_SIZE + '>[' + $breakTechn($techn, '-1') + ']</size>//'
+  !endif
+  !if ($descr != "")
+    !$system = $system + '\n\n' + $descr
+  !endif
+  !return $system
 !endfunction
 
 !unquoted procedure Person($alias, $label, $descr="", $sprite="", $tags="", $link="")
@@ -387,34 +387,34 @@ rectangle "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("external_
 !endif
 !endprocedure
 
-!unquoted procedure System($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure System($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+rectangle "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure System_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure System_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+rectangle "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemDb($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemDb($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+database "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemQueue($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemQueue($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-queue "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+queue "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemDb_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemDb_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+database "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemQueue_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemQueue_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $techn="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-queue "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+queue "$getSystem($label, $techn, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
 ' Boundaries


### PR DESCRIPTION
I would really love the ability to add technologies also to all System* elements, essentially to how it already works for Container*, Component* etc.

My use case is a context diagram that shows that my software interacts with external software systems and, for interchange, it is relevant how they are implemented. Say for example that one of them is a C++/Qt desktop application and that another one is a Python CLI application. I know that the official C4 examples do not really do this, but I think it would be useful nevertheless.

This PR is mostly an RFC to see how this could be implemented in a backwards-compatible fashion. I have added the $techn argument last to the System* procedures so that current diagrams that rely on the argument order are not distrubed. OTOH, this means that the argument order for System* and Component* etc. is different. The $getSystem procedure is a verbatim copy of $getComponent (with $component replaced by $system), so it may be generalized further.