### PR TITLE
#287 System and person support [...] notation

### DIFF
--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -34,17 +34,17 @@ UpdateBoundaryStyle("enterprise", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUND
 UpdateBoundaryStyle("system", $bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $type="System")
 
 ' shortcuts with default colors
-!unquoted procedure AddPersonTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
-  $addElementTagInclReuse("person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
+!unquoted procedure AddPersonTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="", $type="")
+  $addElementTagInclReuse("person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $type, $legendText, $legendSprite)
 !endprocedure
-!unquoted procedure AddExternalPersonTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
-  $addElementTagInclReuse("external_person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
+!unquoted procedure AddExternalPersonTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="", $type="")
+  $addElementTagInclReuse("external_person", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $type, $legendText, $legendSprite)
 !endprocedure
-!unquoted procedure AddSystemTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
-  $addElementTagInclReuse("system", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
+!unquoted procedure AddSystemTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="", $type="")
+  $addElementTagInclReuse("system", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $type, $legendText, $legendSprite)
 !endprocedure
-!unquoted procedure AddExternalSystemTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="")
-  $addElementTagInclReuse("external_system", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, "", $legendText, $legendSprite)
+!unquoted procedure AddExternalSystemTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $legendText="", $legendSprite="", $type="")
+  $addElementTagInclReuse("external_system", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $type, $legendText, $legendSprite)
 !endprocedure
 
 !unquoted procedure UpdateEnterpriseBoundaryStyle($bgColor=$BOUNDARY_BG_COLOR, $fontColor=$BOUNDARY_COLOR, $borderColor=$BOUNDARY_COLOR, $shadowing="", $shape="", $type="Enterprise", $legendText="")
@@ -332,67 +332,83 @@ UpdateElementStyle("external_person")
 ' Elements
 ' ##################################
 
-!function $getPerson($label, $descr, $sprite)
+!function $getPerson($label, $type, $descr, $sprite)
   !if ($sprite == "") && ($defaultPersonSprite != "")
     !$sprite = $defaultPersonSprite
   !endif
-  !return $getElementBase($label, "", $descr, $sprite)
+  !return $getElementBase($label, $type, $descr, $sprite)
 !endfunction
 
-!function $getSystem($label, $descr, $sprite)
-  !return $getElementBase($label, "", $descr, $sprite)
+!function $getSystem($label, $type, $descr, $sprite)
+  !return $getElementBase($label, $type, $descr, $sprite)
 !endfunction
 
-!unquoted procedure Person($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure Person($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "person")
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "person")
 !if ($portraitPerson == "portrait") && ($sprite == "")
-actor "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
+actor "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
 !elseif ($portraitPerson == "outline") && ($sprite == "")
-person "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
+person "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
 !else
-rectangle "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
+rectangle "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
 !endif
 !endprocedure
 
-!unquoted procedure Person_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure Person_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_person")
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "external_person")
 !if ($portraitPerson == "portrait") && ($sprite == "")
-actor "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
+actor "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
 !elseif ($portraitPerson == "outline") && ($sprite == "")
-person "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
+person "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
 !else
-rectangle "$getPerson($label, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
+rectangle "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
 !endif
 !endprocedure
 
-!unquoted procedure System($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure System($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "system")
+rectangle "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure System_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure System_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-rectangle "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "external_system")
+rectangle "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemDb($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemDb($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "system")
+database "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemQueue($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemQueue($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "system")
-queue "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "system")
+queue "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemDb_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemDb_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-database "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "external_system")
+database "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
-!unquoted procedure SystemQueue_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure SystemQueue_Ext($alias, $label, $descr="", $sprite="", $tags="", $link="", $type="")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_system")
-queue "$getSystem($label, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
+' $type reuses $techn definition of $tags
+!$type=$toElementArg($type, $tags, "ElementTagTechn", "external_system")
+queue "$getSystem($label, $type, $descr, $sprite)$getProps()" $toStereos("external_system", $tags) as $alias $getLink($link)
 !endprocedure
 
 ' Boundaries

--- a/C4_Deployment.puml
+++ b/C4_Deployment.puml
@@ -21,9 +21,10 @@ skinparam rectangle<<node>> {
 }
 
 ' shortcuts with default colors
-' node specific: $type reuses $techn definition of $tags
-!unquoted procedure AddNodeTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $techn="", $legendText="", $legendSprite="")
-  $addElementTagInclReuse("node", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $techn, $legendText, $legendSprite)
+' node specific: $techn is only used in old scripts, new scripts uses $type ($techn has to remain, it could be called via named argument)
+!unquoted procedure AddNodeTag($tagStereo, $bgColor="", $fontColor="", $borderColor="", $shadowing="", $shape="", $sprite="", $type="", $legendText="", $legendSprite="", $techn="")
+  !$type=$type+$techn
+  $addElementTagInclReuse("node", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape, $sprite, $type, $legendText, $legendSprite)
 !endprocedure
 
 ' Layout

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ SHOW_LEGEND()
 - System Context & System Landscape diagrams
   - Import: `!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml`
   - Macros:
-    - `Person(alias, label, ?descr, ?sprite, ?tags, ?link)`
+    - `Person(alias, label, ?descr, ?sprite, ?tags, ?link, ?type)`
     - `Person_Ext`
-    - `System(alias, label, ?descr, ?sprite, ?tags, ?link)`
+    - `System(alias, label, ?descr, ?sprite, ?tags, ?link, ?type)`
     - `SystemDb`
     - `SystemQueue`
     - `System_Ext`
@@ -240,6 +240,8 @@ SHOW_LEGEND()
     - `person2`
     - `robot`
     - `robot2`
+
+  - C4 Model extension: Person() and System() support `$type` argument too. Is uses the same notation as `$techn`, e.g. `$type="characteristic A"` is displayed as `[characteristic A]`
 
 - Container diagram
   - Import: `!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml`
@@ -576,10 +578,10 @@ AddPersonTag("admin", $sprite="osa_user_audit", $legendText="administration user
 
 Following calls introduces new element tags with element specific default colors:
 
-- `AddPersonTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite)`
-- `AddExternalPersonTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite)`
-- `AddSystemTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite)`
-- `AddExternalSystemTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite)`
+- `AddPersonTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite, ?type)`
+- `AddExternalPersonTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite, ?type)`
+- `AddSystemTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite, ?type)`
+- `AddExternalSystemTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?legendText, ?legendSprite, ?type)`
 - `AddComponentTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`
 - `AddExternalComponentTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`
 - `AddContainerTag(tagStereo, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite)`

--- a/percy/TestSystemPersonSupportType.puml
+++ b/percy/TestSystemPersonSupportType.puml
@@ -1,0 +1,27 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Container.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!endif
+
+' e.g. during first discussions no sprites are available but the categories should be displayed in the UI
+AddExternalPersonTag("anonymous_ext", $type="anonymous user")
+AddPersonTag("customer", $type="aggregated user")
+AddPersonTag("admin", $legendText="administration user", $type="administrator")
+AddExternalSystemTag("git_repository", $type="web-based Git repository")
+
+Person_Ext(anonymous_user_v1, "Bob", "simplified version during first discussions ($type defines the role), after discussion the $type can be replaced with concrete $sprite", $type="anonymous user")
+Person(aggregated_user_v1, "Sam, Ivone", $tags="customer", $type="replaced with customer")
+Person(administration_user_v1, "Bernd", $tags="admin")
+
+System(system1, "System 1", $type="new developed system")
+
+System_Ext(github, "GitHub", $tags="git_repository", $type="graphical web-based Git repository")
+System_Ext(gitlab, "GitLab", $tags="git_repository")
+
+Person_Ext(anonymous_user_v2, "Bob v2", "Update with sprites", $sprite="robot2")
+
+HIDE_STEREOTYPE()
+@enduml


### PR DESCRIPTION
close #287

**C4 Model extension:** Person() and System() support `$type` argument too. 
Is uses the same notation as `$techn`, e.g. `$type="characteristic A"` is displayed as `[characteristic A]`

Following macros are extended with the optional argument $type:
- AddPersonTag(), AddExternalPersonTag(), AddSystemTag(), AddExternalSystemTag() is extended with $type as last argument.
- Person(), System(),... is extended with $type as last argument.
- cleanup of AddNodeTag() that it can use $type like in the Node() call itself.

```plantuml
@startuml
' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
!if %variable_exists("RELATIVE_INCLUDE")
  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Container.puml
!else
  !include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml
!endif

' e.g. during first discussions no sprites are available but the categories should be displayed in the UI
AddExternalPersonTag("anonymous_ext", $type="anonymous user")
AddPersonTag("customer", $type="aggregated user")
AddPersonTag("admin", $legendText="administration user", $type="administrator")
AddExternalSystemTag("git_repository", $type="web-based Git repository")

Person_Ext(anonymous_user_v1, "Bob", "simplified version during first discussions ($type defines the role), after discussion the $type can be replaced with concrete $sprite", $type="anonymous user")
Person(aggregated_user_v1, "Sam, Ivone", $tags="customer", $type="replaced with customer")
Person(administration_user_v1, "Bernd", $tags="admin")

System(system1, "System 1", $type="new developed system")

System_Ext(github, "GitHub", $tags="git_repository", $type="graphical web-based Git repository")
System_Ext(gitlab, "GitLab", $tags="git_repository")

!define osaPuml https://raw.githubusercontent.com/Crashedmind/PlantUML-opensecurityarchitecture2-icons/master
!include osaPuml/Common.puml
!include osaPuml/User/all.puml

Person_Ext(anonymous_user_v2, "Bob 2", "Update with sprites", $sprite="osa_user_black_hat")
Person(aggregated_user_v2, "Sam, Ivone 2", $tags="customer", $sprite="osa_user_large_group")
Person(administration_user_v2, "Bernd 2", $tags="admin", $sprite="osa_user_audit,color=red")

HIDE_STEREOTYPE()
@enduml
```

![](https://www.plantuml.com/plantuml/png/ZLHXQ-D64FtkNp4nFUg0RN6cdmg6kpgcPqZRSB4B_IJ6sh6qt6fNpCuwyR_lo4igftNI-oJOcVVUphod_HG5MLBhHZz25VoHMC0AF5bf08snOeD7fwMsHM_0MK-0NAUMlC3ixklw_lDsy-UwtFo-kj_ThPVZUJ6VZq42f4ZWGeNEdKOtzW0VZiWMzuvAUhPHucJyR_3uTWHmOttbaY7uK9EK_s2Ew19TWnIhdyfLy8BM4y-xVf8RSf4kgHgHBlvS58nFyredI_iKYIj5aPUvpbPyirmrKHfbcpquzBBxxRwWPwqRCbSblB67aIwDvlKSJ6BhQpXOZWB6nYh5Q8EFu0F4ZgrG16G2FA9r_JomJmBI45GeL0UssX2Ra9o1FVKCdSCJ6R3-tBNRZ3uRizRxi4VtG1o3ts8z6QCF_jI657MfCfx23tBgQ3aSzowmxbNH5oYzdeIM-09Grqmr2fdh23IjzNsxevgysQhQCX_QA8nzIZ9mO1oAGVakx_zuYaBjcLVTA9cw4ArsdGRq4-rdUunau5ShC7GeqIXVgrIsoJ1-BruUFqvX_4lOAyyushPpzc2LuaZSk_6sIvEpAXWwM4_nl74EZcwdW0SX7dgp6xcxGjzxnQHMLMJoBrC5Np69zcJRtx4aZp4PDdynmoEsKzWSWyy4MCVb5TDUI-Vw9VLhVovNHEpDm9pDrSrcOoRn_EaRym5y73GzFO6X8xdGgN3k7A1dK_8VfcYrxalQ3pflcLqpTesjqC4xjhyMS9W5v1xV5j1htMHF8KHyIAtxZfTWnHWRwZTYYfUNOAR3-aXLOYidvAgnGfKafiNCAZOMBKOX7hqyE2zonIgqRV3voVXFSQVA1JgNo-_5Uf5Z3Oi-sBlEe53sF8Siwd7EcovJsJDgxx3wLZOexsHjyIfhiBYMjYlK3hccikQGklz9s-8bRPVSvywhn9YCbMaLNE0ba-aT_BAvMvUFs_NNzH_RlnxMazlH9_96D_Ot)

It can be tested with [my extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended)

@mtnpke, @Potherca: `$type` enables the simplest merge, therefore I didn't change it, but if you want I still can change it in this PR

BR
Helmut