### PR TITLE
Allow use of collections in c4 diagrams

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -124,6 +124,10 @@ skinparam rectangle {
     StereotypeFontSize $STEREOTYPE_FONT_SIZE
 }
 
+skinparam collections {
+    StereotypeFontSize $STEREOTYPE_FONT_SIZE
+}
+
 skinparam database {
     StereotypeFontSize $STEREOTYPE_FONT_SIZE
 }
@@ -347,6 +351,7 @@ skinparam package {
 !unquoted procedure $defineSkinparams($tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape)
   ' only rectangle supports shape(d corners)
   !$tagSkin = $elementTagSkinparams("rectangle", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, $shape)
+  !$tagSkin = $tagSkin + $elementTagSkinparams("collections", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   !$tagSkin = $tagSkin + $elementTagSkinparams("database", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   !$tagSkin = $tagSkin + $elementTagSkinparams("queue", $tagStereo, $bgColor, $fontColor, $borderColor, $shadowing, "")
   ' plantuml.jar bug - actor have to be after person


### PR DESCRIPTION
Currently, there is no way to create a collection in either context or container level. Here is an example showing how a RBAC permission system can work:

![image](https://github.com/plantuml-stdlib/C4-PlantUML/assets/944916/1e158f02-1315-4ef1-a23a-e885bea3a4d6)
