### PR TITLE
#320 Dynamic/Sequence fix Rel() without $index argument

### DIFF
--- a/C4_Dynamic.puml
+++ b/C4_Dynamic.puml
@@ -35,9 +35,13 @@ $getRel($direction, $alias1, $alias2, $e_index + ": " + $label, $techn, "", "", 
 
 ' all RelIndex... calls are outdated, Rel(..., $index=...) calls should be used !!!!
 
+' first Rel() supports the $index argument too; second Rel() overwrites C4.puml definition
 !unquoted procedure Rel($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
 $getRel("-->>", $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel("-->>", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
@@ -47,6 +51,9 @@ $getRel("-->>", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $
 !$pre = $getPrefix($index)
 $getRel("<<--", $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
+!unquoted procedure Rel_Back($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Back($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
+!endprocedure
 !unquoted procedure RelIndex_Back($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel("<<--", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
@@ -54,6 +61,9 @@ $getRel("<<--", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $
 !unquoted procedure Rel_Neighbor($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
 $getRel("->>", $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel_Neighbor($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Neighbor($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex_Neighbor($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel("->>", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
@@ -63,6 +73,9 @@ $getRel("->>", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $t
 !$pre = $getPrefix($index)
 $getRel("<<-", $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
+!unquoted procedure Rel_Back_Neighbor($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Back_Neighbor($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
+!endprocedure
 !unquoted procedure RelIndex_Back_Neighbor($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel("<<-", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
@@ -71,9 +84,15 @@ $getRel("<<-", $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $t
 !$pre = $getPrefix($index)
 $getRel($down("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
+!unquoted procedure Rel_D($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_D($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
+!endprocedure
 !unquoted procedure Rel_Down($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
 $getRel($down("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel_Down($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Down($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex_D($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel($down("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
@@ -86,9 +105,15 @@ $getRel($down("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, 
 !$pre = $getPrefix($index)
 $getRel($up("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
+!unquoted procedure Rel_U($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_U($from, $to, $label, $techn, $descr, $sprite, $tags, $link=, "")
+!endprocedure
 !unquoted procedure Rel_Up($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
 $getRel($up("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel_Up($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Up($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex_U($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel($up("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
@@ -101,9 +126,15 @@ $getRel($up("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, $s
 !$pre = $getPrefix($index)
 $getRel($left("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
-!unquoted procedure Rel_Left($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+!unquoted procedure Rel_L($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_L($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
-$getRel($left("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link, $index="")
+$getRel($left("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Left($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex_L($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel($left("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)
@@ -116,9 +147,15 @@ $getRel($left("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, 
 !$pre = $getPrefix($index)
 $getRel($right("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
 !endprocedure
+!unquoted procedure Rel_R($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_R($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
+!endprocedure
 !unquoted procedure Rel_Right($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="")
 !$pre = $getPrefix($index)
 $getRel($right("-","->>"), $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel_Right($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel_Right($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "")
 !endprocedure
 !unquoted procedure RelIndex_R($e_index, $from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
 $getRel($right("-","->>"), $from, $to, $e_index + ": " + $label, $techn, $descr, $sprite, $tags, $link)

--- a/C4_Sequence.puml
+++ b/C4_Sequence.puml
@@ -380,6 +380,7 @@ end box
 
 ' only Rel is supported in sequence diagram
 
+' first Rel() supports the $index and $rel argument too; second Rel() overwrites C4.puml definition
 ' don't add empty lines in procedure otherwise & calls are not working anymore '& a -> b: call' are not working anymore
 !unquoted procedure Rel($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="", $index="", $rel="")
   !if ($show_index == %true())
@@ -391,4 +392,7 @@ end box
     !$rel = "->"
   !endif
 $getRel($rel, $from, $to, $pre + $label, $techn, $descr, $sprite, $tags, $link)
+!endprocedure
+!unquoted procedure Rel($from, $to, $label, $techn="", $descr="", $sprite="", $tags="", $link="")
+Rel($from, $to, $label, $techn, $descr, $sprite, $tags, $link, "", "")
 !endprocedure


### PR DESCRIPTION
related to #320 

fix overwrites the already existing (C4.puml specific) Rel...() definitions in C4_Dynamic.puml and C4_Sequence.puml too.
Based on that PlantUML resolves all Rel...() deterministic with one of the correct implementations.

It can be tested with my external branch, like below 

```plantuml
!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Dynamic.puml
```

[![](http://www.plantuml.com/plantuml/svg/RP51QuGm58Jl_ehKoxw5L2yzzRHOZnQAPQ7jPSacwIPKNoG-sIwb_xsl7hJL5Hp6cJ1yn5rFAjBGDicDHzqCnWf7rFNtUHxLEJjvSiDnw6tK0SaYPJgq-OUFslNayeUxswT68UqVgzn-Sc-iuV1GNb2rNcVTxt1IX06DYXTGKcnA7wqc7r2aQMsRDDrilnB13tySod16c9mKuaNoiUtKxpkO7BUhllOdHp0vkUmh-qumkNd_-m_ayHgaU7OXabDe_k72g5AyBZ1Xr5LUmwYhl89HEL_ZQCRXE_Op2aEmB_poze1VATxcwV4853xEEK_lB1h-BJy0)](http://www.plantuml.com/plantuml/uml/RP51QuGm58Jl_ehKoxw5L2yzzRHOZnQAPQ7jPSacwIPKNoG-sIwb_xsl7hJL5Hp6cJ1yn5rFAjBGDicDHzqCnWf7rFNtUHxLEJjvSiDnw6tK0SaYPJgq-OUFslNayeUxswT68UqVgzn-Sc-iuV1GNb2rNcVTxt1IX06DYXTGKcnA7wqc7r2aQMsRDDrilnB13tySod16c9mKuaNoiUtKxpkO7BUhllOdHp0vkUmh-qumkNd_-m_ayHgaU7OXabDe_k72g5AyBZ1Xr5LUmwYhl89HEL_ZQCRXE_Op2aEmB_poze1VATxcwV4853xEEK_lB1h-BJy0)

Best regards
Helmut


