### PR TITLE
fix deprecated task in build: update to ts-graphviz/setup-graphviz@v2

### DIFF
--- a/.github/workflows/run-percy-tests.yml
+++ b/.github/workflows/run-percy-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
+        uses: ts-graphviz/setup-graphviz@v2
       - name: Process diagrams
         uses: Timmy/plantuml-action@v1
         with:


### PR DESCRIPTION
fix build warning: "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ts-graphviz/setup-graphviz@v1"