### PR TITLE
#355 Single column property

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -1151,9 +1151,12 @@ $elementSkin
 !global $propTableCaption = ""
 !global $propColCaption = "="
 
-!unquoted function SetPropertyHeader($col1Name, $col2Name, $col3Name = "", $col4Name = "")
+!unquoted function SetPropertyHeader($col1Name, $col2Name = "", $col3Name = "", $col4Name = "")
   !$propColCaption = ""
-  !$propTableCaption = "|= " + $col1Name + " |= " + $col2Name + " |"
+  !$propTableCaption = "|= " + $col1Name + " |"
+  !if ($col2Name != "")
+    !$propTableCaption = $propTableCaption + "= " + $col2Name + " |"
+  !endif
   !if ($col3Name != "")
     !$propTableCaption = $propTableCaption + "= " + $col3Name + " |"
   !endif
@@ -1169,7 +1172,7 @@ $elementSkin
   !return ""
 !endfunction
 
-!unquoted function AddProperty($col1, $col2, $col3 = "", $col4 = "")
+!unquoted function AddProperty($col1, $col2 = "", $col3 = "", $col4 = "")
   !if ($propTable == "")
     !if ($propTableCaption != "")
       !$propTable = $propTableCaption + "\n"
@@ -1177,7 +1180,10 @@ $elementSkin
   !else
     !$propTable = $propTable + "\n"
   !endif
-  !$propTable = $propTable + "| " + $col1 + " |" + $propColCaption + " " + $col2 + " |"
+  !$propTable = $propTable + "| " + $col1 + " |"
+  !if ($col2 != "")
+    !$propTable = $propTable + $propColCaption + " " + $col2 + " |"
+  !endif
   !if ($col3 != "")
     !$propTable = $propTable + " " + $col3 + " |"
   !endif

--- a/README.md
+++ b/README.md
@@ -875,11 +875,11 @@ SHOW_LEGEND()
 
 A model can be extended with (a table of) properties that concrete deployments or more detailed concepts can be documented:
 
-- `SetPropertyHeader(col1Name, col2Name, ?col3Name, ?col4Name)`
+- `SetPropertyHeader(col1Name, ?col2Name, ?col3Name, ?col4Name)`
   The properties table can have up to 4 columns. The default header uses the column names "Name", "Description".
 - `WithoutPropertyHeader()`
   If no header is used, then the second column is bold.
-- `AddProperty(col1, col2, ?col3, ?col4)`
+- `AddProperty(col1, ?col2, ?col3, ?col4)`
   (All columns of) a property which will be added to the next element.
 
 Following sample uses all 3 different property definitions (and the aligned deployment node).

--- a/percy/TestProperty.puml
+++ b/percy/TestProperty.puml
@@ -1,0 +1,36 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Deployment.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml
+!endif
+
+' default header Property, Value
+AddProperty("Name", "Flash")
+AddProperty("Organization", "Zootopia")
+AddProperty("Tool", "Internet Explorer 7.0")
+Person(personAlias, "Label", "Optional Description (with default property header)")
+
+SetPropertyHeader("Property","Value", "Description")
+AddProperty("Prop1", "Value1", "Details1")
+AddProperty("Prop2", "Value2", "Details2")
+Deployment_Node_L(nodeAlias, "Label", "Optional Type", "Optional Description (with custom property header)") {
+
+  WithoutPropertyHeader()
+  AddProperty("PropC1", "ValueC1")
+  AddProperty("PropC2", "ValueC2")
+  Container(containerAlias, "Label", "Technology", "Optional Description (without property header)")
+}
+
+SetPropertyHeader("Property")
+AddProperty("Value1")
+AddProperty("Value2")
+System(systemAlias, "Label", "Optional Description\n(single column property)")
+
+' starting with v.2.5.0 relationships support properties too
+WithoutPropertyHeader()
+AddProperty("PropC1", "ValueC1")
+AddProperty("PropC2", "ValueC2")
+Rel(personAlias, containerAlias, "Label", "Optional Technology", "Optional Description")
+@enduml


### PR DESCRIPTION
related to #355

SetPropertyHeader() and AddProperty() are updated that only 1 column is required (the old implementation required at least 2 columns)

- `SetPropertyHeader(col1Name, ?col2Name, ?col3Name, ?col4Name)`
- `AddProperty(col1, ?col2, ?col3, ?col4)`


[![](https://www.plantuml.com/plantuml/svg/ROn1IqCn383lxrVKdjv0LnHFdZRSmSF4mT2J85qRzeffMf8KVV_URhZRJidt9NmhKS_QCWutYGAs26PIhVBa7FkVvJ7fr0vDW4CX1T9bADbz9mwJwEIU7-zsw4dVNxSEVlizGkpoQmCLovnF__NK7lQWEouLMESNy15uj1UsYs4TuuL6--6nmVrL-z3jVXQ5FCfvh35vkJLswm-0jYzlLLCXZsO34ZYTwPD6INH4CA5WosJgVtNHSyCAABQCVm00)](https://www.plantuml.com/plantuml/uml/ROn1IqCn383lxrVKdjv0LnHFdZRSmSF4mT2J85qRzeffMf8KVV_URhZRJidt9NmhKS_QCWutYGAs26PIhVBa7FkVvJ7fr0vDW4CX1T9bADbz9mwJwEIU7-zsw4dVNxSEVlizGkpoQmCLovnF__NK7lQWEouLMESNy15uj1UsYs4TuuL6--6nmVrL-z3jVXQ5FCfvh35vkJLswm-0jYzlLLCXZsO34ZYTwPD6INH4CA5WosJgVtNHSyCAABQCVm00)

It can be tested via my [extended branch](https://github.com/kirchsth/C4-PlantUML/tree/extended).

@chriskn can you please test it?

BR Helmut