### PR TITLE
#379 correct typo in Italian legend title

### DIFF
--- a/themes/puml-theme-C4Language_italian.puml
+++ b/themes/puml-theme-C4Language_italian.puml
@@ -2,7 +2,7 @@
 
 !$BOUNDARY_LEGEND_TEXT ?= "confine"
 
-!$LEGEND_TITLE_TEXT ?= "Leggenda"
+!$LEGEND_TITLE_TEXT ?= "Legenda"
 
 !$LEGEND_BOUNDARY ?= "confine"
 !$LEGEND_BOUNDARY_PRE_PART ?= "confine del "


### PR DESCRIPTION
The correct italian for "legend" is "legenda". "Leggenda" means more or less "mythical narration".

The https://github.com/plantuml/plantuml-stdlib/pull/128 of the "derived" [plantuml-stdlib](https://github.com/plantuml/plantuml-stdlib) has to be merged into the "original" [C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML) too.