### PR TITLE
#383 fill undefined property columns and complete header columns

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -1161,28 +1161,107 @@ $elementSkin
 !global $propTableCaption = ""
 !global $propColCaption = "="
 
+!global $isFirstProp = 1
+!global $firstPropCol = 1
+!global $lastPropCol = 1
+
+!function $fillMissing($col, $colNext)
+  !if ($col == "" && $colNext != "")
+    !return " "
+  !endif
+  !return $col 
+!endfunction
+
+!function $updatePropColumns($colIdx)
+  !if ($isFirstProp == 1 && $colIdx > $firstPropCol)
+    !$firstPropCol = $colIdx
+  !endif    
+  !if ($isFirstProp == 0 && $colIdx > $lastPropCol)
+    !$lastPropCol = $colIdx
+  !endif    
+  !return "" 
+!endfunction
+
+' add missing header columns, if a following row has more columns
+' (fixed in PlantUML v1.2025.1beta9; only required in older versions)
+!function $fixHeaderColumns()
+  ' the number of displayed columns considers only the first row
+  ' if another row has more columns the first has to be filled with missing columns 
+  !if ($lastPropCol > $firstPropCol)
+    !$delta = $lastPropCol - $firstPropCol
+    !$delta = $delta * 2
+    !$fix = %substr(" | | | |", 0, $delta)
+
+    ' basically the line break \n should be the split
+    ' but \n is not encoded (anymore?) therefore split only via
+    ' \ and remove the last obsolete  \ (changed order with add 
+    ' \ at the beginning is not working). 
+    ' "\n" would split \ and n ==> n would be an unwanted line break 
+    !$lines = %splitstr($propTable, "\")
+    ' !$lines = %splitstr_regex($propTable, "(?=[\x000A])")
+    !$first = 1
+    !$newTab = ""
+    !foreach $item in $lines
+      !if ($first == 1)
+        !$item = $item + $fix
+        !$first = 0
+      !endif
+      !$newTab = $newTab + $item + "\"
+    !endfor
+    
+    !$fixLen = %strlen($newTab) - 1
+    !$newTab = %substr($newTab, 0, $fixLen)
+
+    !$propTable = $newTab
+  !endif    
+
+  !$isFirstProp = 1
+  !$firstPropCol = 1
+  !$lastPropCol = 1
+
+  !return "" 
+!endfunction
+
 !unquoted function SetPropertyHeader($col1Name, $col2Name = "", $col3Name = "", $col4Name = "")
+  !$col3Name = $fillMissing($col3Name, $col4Name)
+  !$col2Name = $fillMissing($col2Name, $col3Name)
+  !$col1Name = $fillMissing($col1Name, $col2Name)
+
   !$propColCaption = ""
   !$propTableCaption = "|= " + $col1Name + " |"
   !if ($col2Name != "")
     !$propTableCaption = $propTableCaption + "= " + $col2Name + " |"
+    $updatePropColumns(2)
   !endif
   !if ($col3Name != "")
     !$propTableCaption = $propTableCaption + "= " + $col3Name + " |"
+    $updatePropColumns(3)
   !endif
   !if ($col4Name != "")
     !$propTableCaption = $propTableCaption + "= " + $col4Name + " |"
+    $updatePropColumns(4)
   !endif
+
+  !$isFirstProp = 0
   !return ""
 !endfunction
 
 !unquoted function WithoutPropertyHeader()
   !$propTableCaption = ""
   !$propColCaption = "="
+
+  !$isFirstProp = 1
+  !$firstPropCol = 1
+  !$lastPropCol = 1
+
   !return ""
 !endfunction
 
 !unquoted function AddProperty($col1, $col2 = "", $col3 = "", $col4 = "")
+  !$col3 = $fillMissing($col3, $col4)
+  !$col2 = $fillMissing($col2, $col3)
+  !$col1 = $fillMissing($col1, $col2)
+
   !if ($propTable == "")
     !if ($propTableCaption != "")
       !$propTable = $propTableCaption + "\n"
@@ -1190,20 +1269,28 @@ $elementSkin
   !else
     !$propTable = $propTable + "\n"
   !endif
+
   !$propTable = $propTable + "| " + $col1 + " |"
   !if ($col2 != "")
     !$propTable = $propTable + $propColCaption + " " + $col2 + " |"
+    $updatePropColumns(2)
   !endif
   !if ($col3 != "")
     !$propTable = $propTable + " " + $col3 + " |"
+    $updatePropColumns(3)
   !endif
   !if ($col4 != "")
     !$propTable = $propTable + " " + $col4 + " |"
+    $updatePropColumns(4)
   !endif
+
+  !$isFirstProp = 0
   !return ""
 !endfunction
 
 !unquoted function $getProps($alignedNL = "\n")
+  $fixHeaderColumns()
+
   !if ($propTable != "")
     !$retTable = $alignedNL + $propTable
     !$propTable = ""

--- a/percy/TestPropertyMissingColumns.puml
+++ b/percy/TestPropertyMissingColumns.puml
@@ -1,0 +1,19 @@
+@startuml
+' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Deployment.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml
+!endif
+
+' missing columns 3 and 4 are added that all columns are displayed
+SetPropertyHeader("", $col2Name="2")
+AddProperty($col1="col1")
+AddProperty("", $col2="col2")
+AddProperty(" ", " ", $col3="col3")
+' missing columns 2 and 3 are inserted with empty values
+AddProperty("", $col4="col4")
+
+Container(c, "Container")
+
+@enduml


### PR DESCRIPTION
related to #383 

Property tables have 2 problems
a) if a column is missing then the values of the following columns are moved left too
b) if a header has less columns than the following rows the following rows are truncated too

eg. following code produces following image

```plantuml
@startuml
!include <C4/C4.puml>
!include <C4/C4_Container.puml>

' at b) header has only 2 columns, therefore col3 is not displayed
SetPropertyHeader("", $col2Name="2")
AddProperty($col1="col1")
AddProperty("", $col2="col2")
AddProperty(" ", " ", $col3="col3")
' at a) col4 is displayed in column 2 and not 4
AddProperty("", $col4="col4")

Container(c, "Container")
@enduml
```

![](https://www.plantuml.com/plantuml/png/VP31IiGm48RlUOhV8DZ2eXXpT6Mb5qyY-00Icv46qab9qaFVtgJM7dhOoq3-RpBpCPUKJSppwCMDuzxFbl3SwOTEtqybV3ccNrtWR1nJtBYuWyduRZ6GiHGnc8J0Ve527_mySZeX3nJf9qIgqHDS0eSCwzBapK9MV5B-Y66Yc9UtTKeZvGctfLczcv7EKibMl5hxtzHKz7YMjHx8_d6bwaXHS2djdxLfgv2kGhiC76_YK31iLrLzPOSkqyH-bQOl2_PNGHTYMmxr2m00)

Both problems are fixed with this MR and can be checked via my extended branch

[![](https://www.plantuml.com/plantuml/png/RP91Qzj048Nl-XNZfQ4kD19rV2eO4cn30su8RTEhcMWdrj3TbTYTTQ9_trbCHN5y6H3llHczJxfDWb6oTzL7QFjmf2Z00gyi7Q2rBDm7T2fvZy62uq20yP0z1O7hpO_jxkxN_U_j_lvXlNlQR5UcRkhQWFIG4u7hMtHkh6Ry0bT7Z8pFZlRqnadIt9o7pQSAOCQXTTaIN1r8zbFcY2xJfKYpNkutDBX-BAzK3wNAZ5oY_tTr8aFwsZGHN-k3LilFEL7Klb8oMgxvmx7jadIwxlhHOP2dxxk6tbItP2_UK8LVAiNcEIKE1sNaiWy9Rg2GMYecAWZ9WdGee20cIv4ify7XIBRwIV8O-q7HZzy8BSMvCP_XWveN3-XfPHPAvixQVwPvaRwiJ9bdoXHKLUUv2YhhE7bkrADJFUyxB4g7qYGIS4YQ9dlwASWFCaBv79GkdbxgMfswjbehOEIWXLgzEpsfTAlqbE9V)](https://www.plantuml.com/plantuml/uml/RP91Qzj048Nl-XNZfQ4kD19rV2eO4cn30su8RTEhcMWdrj3TbTYTTQ9_trbCHN5y6H3llHczJxfDWb6oTzL7QFjmf2Z00gyi7Q2rBDm7T2fvZy62uq20yP0z1O7hpO_jxkxN_U_j_lvXlNlQR5UcRkhQWFIG4u7hMtHkh6Ry0bT7Z8pFZlRqnadIt9o7pQSAOCQXTTaIN1r8zbFcY2xJfKYpNkutDBX-BAzK3wNAZ5oY_tTr8aFwsZGHN-k3LilFEL7Klb8oMgxvmx7jadIwxlhHOP2dxxk6tbItP2_UK8LVAiNcEIKE1sNaiWy9Rg2GMYecAWZ9WdGee20cIv4ify7XIBRwIV8O-q7HZzy8BSMvCP_XWveN3-XfPHPAvixQVwPvaRwiJ9bdoXHKLUUv2YhhE7bkrADJFUyxB4g7qYGIS4YQ9dlwASWFCaBv79GkdbxgMfswjbehOEIWXLgzEpsfTAlqbE9V)

(PlantUML >= v1.2025.1beta9 has a bugfix of b), the hidden columns based ob incomplete headers, but I still added this fix, that it works with older versions too) 

BR
Helmut