### PR TITLE
Fix for "Use !option handwritten true" warning

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -1392,7 +1392,25 @@ hide stereotype
 !endprocedure
 
 !procedure LAYOUT_AS_SKETCH()
+!$counter=0
+!foreach $versionPart in %splitstr(%version(), ".")
+  !$counter=$counter+1
+
+  !if ($counter == 2)
+    !$year=$versionPart
+  !endif
+
+  !if ($counter == 3)
+    !$minor=$versionPart
+  !endif
+!endfor
+
+!if ($year < 2025) || ($year == 2025 && $minor == 0)
   skinparam handwritten true
+!else
+  !option handwritten true
+!endif
+
 !if $SKETCH_BG_COLOR > ""
   skinparam backgroundColor $SKETCH_BG_COLOR
 !endif


### PR DESCRIPTION
C4-PlantUML is compatible up to v1.2023.5 (because of the `?=` operator being used).

We can't use JSON notation (i.e. `$versionPart[1]`) as that triggers a ClassCastException in versions older than v1.2024.5.

The function `%splitstr()` is safe, as it was added in v1.2022.2

Fixes #396