### PR TITLE
Fix: Properties are displayed incorrectly in Sequence diagrams (leakage between elements)

### DIFF
--- a/C4_Sequence.puml
+++ b/C4_Sequence.puml
@@ -206,6 +206,7 @@ skinparam participantRoundCorner $ROUNDED_BOX_SIZE
   !$calcTech = "//<size:" + $TECHN_FONT_SIZE + ">[" + $breakNewLineTechn($techn) + "]</size>//"
   !$calcDescr = $breakNewLineDescr($descr)
   !$calcLink = $getLink($link)
+  !$props = $getProps()
 
 participant $alias $stereo $calcLink [
 !if ($sprite != "")


### PR DESCRIPTION
Fixes #413

Properties in Sequence diagrams were leaking between elements because the props variable was not being cleared between participants.

## Changes
- Added `!$props = $getProps()` call at the beginning of the `$getParticipant` procedure
- This ensures each participant starts with a clean property state, preventing property leakage into subsequent relationships

## Issue Details
When defining Containers with Properties in Sequence diagrams, those Properties were leaking into subsequent relationships (Rel) and displaying there collectively. This was caused by the props variable not being reset between element definitions.