### PR TITLE
#451:  SHOW_ELEMENT_TYPE() in "technology area";  and build agent fixes 

### DIFF
--- a/.github/workflows/run-percy-tests.yml
+++ b/.github/workflows/run-percy-tests.yml
@@ -14,12 +14,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+
       - name: Process diagrams
         uses: Timmy/plantuml-action@v1
         with:
           args: '-v percy -o _parsed -DRELATIVE_INCLUDE="./.."'
+
       - name: Upload
         run: npx @percy/cli upload percy/_parsed
         env:

--- a/.github/workflows/run-percy-tests.yml
+++ b/.github/workflows/run-percy-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
       - name: Process diagrams

--- a/C4.puml
+++ b/C4.puml
@@ -1599,9 +1599,13 @@ $getLegendArea($alias, $hideStereotype, $details)
 
 'SHOW_ELEMENT_TYPE() shows the element type as part of technology text (and typically hides stereotype too).
 !global $showElementTypeViaTech = %false()
-!unquoted procedure SHOW_ELEMENT_TYPE($hideStereotype="true")
+!global $showPersonTypeViaTech = %false()
+!unquoted procedure SHOW_ELEMENT_TYPE($hideStereotype="true", $hidePersonType="true")
   !global $showElementTypeViaTech = %true()
   $getHideStereotype($hideStereotype)
+  !if ($hidePersonType == "false" || $hidePersonType == %false())
+    !global $showPersonTypeViaTech = %true()
+  !endif
 !endprocedure
 
 !unquoted function $updateTechWithElementType($techn, $elementType)

--- a/C4.puml
+++ b/C4.puml
@@ -1234,6 +1234,7 @@ $elementSkin
 !function $getElementLine($umlShape, $elementType, $alias, $label, $techn, $descr, $sprite, $tags, $link)
   !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", $elementType)
   !$techn=$toElementArg($techn, $tags, "ElementTagTechn", $elementType)
+  !$techn=$updateTechWithElementType($techn, $elementType)
   !$baseProp = $getElementBase($label, $techn, $descr, $sprite) + $getProps()
   !$stereo = $toStereos($elementType,$tags)
   !$calcLink = $getLink($link)
@@ -1595,6 +1596,25 @@ SHOW_LEGEND($hideStereotype)
 !unquoted procedure SHOW_FLOATING_LEGEND($alias=LEGEND(), $hideStereotype="true", $details=Small())
 $getLegendArea($alias, $hideStereotype, $details)
 !endprocedure
+
+'SHOW_ELEMENT_TYPE() shows the element type as part of technology text (and typically hides stereotype too).
+!global $showElementTypeViaTech = %false()
+!unquoted procedure SHOW_ELEMENT_TYPE($hideStereotype="true")
+  !global $showElementTypeViaTech = %true()
+  $getHideStereotype($hideStereotype)
+!endprocedure
+
+!unquoted function $updateTechWithElementType($techn, $elementType)
+  !if $showElementTypeViaTech
+    !$legendText=$restoreEmpty($elementType, "legendText", "", %false())
+    !if $techn>""
+      !$techn=$legendText + ": " + $techn
+    !else
+      !$techn=$legendText
+    !endif
+  !endif
+  !return $techn
+!endfunction
 
 ' Boundaries
 ' ##################################

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -372,6 +372,9 @@ UpdateElementStyle("external_person")
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "person")
 ' $type reuses $techn definition of $tags
 !$type=$toElementArg($type, $tags, "ElementTagTechn", "person")
+!if ($showPersonTypeViaTech == %true())
+  !$type=$updateTechWithElementType($type, "person")
+!endif
 !if ($portraitPerson == "portrait") && ($sprite == "")
 actor "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("person", $tags) as $alias $getLink($link)
 !elseif ($portraitPerson == "outline") && ($sprite == "")
@@ -385,6 +388,9 @@ rectangle "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("pe
 !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", "external_person")
 ' $type reuses $techn definition of $tags
 !$type=$toElementArg($type, $tags, "ElementTagTechn", "external_person")
+!if ($showPersonTypeViaTech == %true())
+    !$type=$updateTechWithElementType($type, "external_person")
+!endif
 !if ($portraitPerson == "portrait") && ($sprite == "")
 actor "$getPerson($label, $type, $descr, $sprite)$getProps()" $toStereos("external_person", $tags) as $alias $getLink($link)
 !elseif ($portraitPerson == "outline") && ($sprite == "")

--- a/C4_Sequence.puml
+++ b/C4_Sequence.puml
@@ -75,8 +75,8 @@ UpdateBoundaryStyle("container", $bgColor=$CONTAINER_BOUNDARY_BG_COLOR, $fontCol
 !if (%variable_exists("$THEME"))
 !else
 ' $BOUNDARY_BG_COLOR... have to be defined in theme itself that it can be used in styles,...
-' (no default values which are defined in C4.puml) 
-' If skinparams and styles are defined with concrete values no variables are required 
+' (no default values which are defined in C4.puml)
+' If skinparams and styles are defined with concrete values no variables are required
 !$BOUNDARY_BG_COLOR ?= "transparent"
 !$BOUNDARY_COLOR ?= "#444444"
 !$ARROW_COLOR ?= "#666666"
@@ -146,7 +146,7 @@ skinparam participantRoundCorner $ROUNDED_BOX_SIZE
     !if ($brPos > 0)
       !$multiLine = $multiLine + %substr($text, 0, $brPos) + $lineEnd + %newline() + $lineStart
     !else
-      ' <U+00A0> non breaking change that newLine breaks with formats can be used with \n\n 
+      ' <U+00A0> non breaking change that newLine breaks with formats can be used with \n\n
       !$multiLine = $multiLine + "<U+00A0>" + $lineEnd + %newline() + $lineStart
     !endif
     !$text = %substr($text, $brPos+2)
@@ -201,6 +201,7 @@ skinparam participantRoundCorner $ROUNDED_BOX_SIZE
 !procedure $getParticipant($elementType, $alias, $label, $techn, $descr, $sprite, $tags, $link)
   !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", $elementType)
   !$techn=$toElementArg($techn, $tags, "ElementTagTechn", $elementType)
+  !$techn=$updateTechWithElementType($techn, $elementType)
   !$stereo = $toStereos($elementType,$tags)
   !$calcLabel = "== " + $breakNewLineLabel($label)
   !$calcTech = "//<size:" + $TECHN_FONT_SIZE + ">[" + $breakNewLineTechn($techn) + "]</size>//"
@@ -322,7 +323,7 @@ $calcDescr
 ' Boundary redefinition
 ' ##################################
 
-' all boundaries have to be displayed as box and 
+' all boundaries have to be displayed as box and
 ' !!! important changes: without { at the end; and boundary ends with Boundary_End() instead of }
 
 ' alias ignored

--- a/C4_Sequence.puml
+++ b/C4_Sequence.puml
@@ -201,7 +201,9 @@ skinparam participantRoundCorner $ROUNDED_BOX_SIZE
 !procedure $getParticipant($elementType, $alias, $label, $techn, $descr, $sprite, $tags, $link)
   !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", $elementType)
   !$techn=$toElementArg($techn, $tags, "ElementTagTechn", $elementType)
-  !$techn=$updateTechWithElementType($techn, $elementType)
+  !if ($elementType!="person" || $showPersonTypeViaTech == %true())
+    !$techn=$updateTechWithElementType($techn, $elementType)
+  !endif
   !$stereo = $toStereos($elementType,$tags)
   !$calcLabel = "== " + $breakNewLineLabel($label)
   !$calcTech = "//<size:" + $TECHN_FONT_SIZE + ">[" + $breakNewLineTechn($techn) + "]</size>//"

--- a/LayoutOptions.md
+++ b/LayoutOptions.md
@@ -8,7 +8,7 @@ C4-PlantUML comes with some layout options.
     - [Overall Guidance](#overall-guidance)
     - [Layout Practices](#layout-practices)
   - [LAYOUT_TOP_DOWN() or LAYOUT_LEFT_RIGHT() or LAYOUT_LANDSCAPE()](#layout_top_down-or-layout_left_right-or-layout_landscape)
-  - [SHOW_ELEMENT_TYPE(?hideStereotype)](#show_element_typehidestereotype)
+  - [SHOW_ELEMENT_TYPE(?hideStereotype, ?hidePersonType)](#show_element_typehidestereotype-hidepersontype)
   - [LAYOUT_WITH_LEGEND() or SHOW_LEGEND(?hideStereotype, ?details)](#layout_with_legend-or-show_legendhidestereotype-details)
   - [SHOW_FLOATING_LEGEND(?alias, ?hideStereotype, ?details) and LEGEND()](#show_floating_legendalias-hidestereotype-details-and-legend)
   - [LAYOUT_AS_SKETCH() and SET_SKETCH_STYLE(?bgColor, ?fontColor, ?warningColor, ?fontName, ?footerWarning, ?footerText)](#layout_as_sketch-and-set_sketch_stylebgcolor-fontcolor-warningcolor-fontname-footerwarning-footertext)
@@ -142,12 +142,14 @@ SHOW_LEGEND()
 
 [![LAYOUT_LANDSCAPE Sample - open link](https://www.plantuml.com/plantuml/svg/NOzFRvj04CNlV8gjUmYM75kfUkef5ApaG1nae55FQ0sJUANzizeTXAAgtxqpCNQiSa7lDxFllRcFA0EEHeio-_tSDbsPxOewpwgjgANn6f8lolPw740S4NtyiTa4EQtV51x7mnWXzCuYM5ptpcoybfQzRYCEMXqs-VVRYb7xL6wCZ0Y1K9VJ2waiXBMdtIJvFpXT9aa58JgRoi4eknABZFygOf3emcAPrEzaPhgVRhI33EzfVxSIDwU-Dqln9n7qNMBI2GwTz9vyNk0WCk-rwYKgPnU4ygyhaTNLUhTjw4a0yMrz9vv-vJpBj7PJ57nc5EW4tUWbhPXHew8iqKmA4O90PK1JLgHkV-TsAPw6v3ElqJ3PWpvVzLchZH0vxx5fgfgsUEao_RHv08maWN-lmPdh9-VGUhLWULOjIT7wAr8mATnahrZ9h8HNl69xPdlrTiIvTjTwSXTrouNPaHaRVT22A8kPiza7Bucpc3aRdWPx6bpiwyVdbwxSFcntHKho7kmm6lqF "LAYOUT_LANDSCAPE Sample")](https://www.plantuml.com/plantuml/uml/NOzFRvj04CNlV8gjUmYM75kfUkef5ApaG1nae55FQ0sJUANzizeTXAAgtxqpCNQiSa7lDxFllRcFA0EEHeio-_tSDbsPxOewpwgjgANn6f8lolPw740S4NtyiTa4EQtV51x7mnWXzCuYM5ptpcoybfQzRYCEMXqs-VVRYb7xL6wCZ0Y1K9VJ2waiXBMdtIJvFpXT9aa58JgRoi4eknABZFygOf3emcAPrEzaPhgVRhI33EzfVxSIDwU-Dqln9n7qNMBI2GwTz9vyNk0WCk-rwYKgPnU4ygyhaTNLUhTjw4a0yMrz9vv-vJpBj7PJ57nc5EW4tUWbhPXHew8iqKmA4O90PK1JLgHkV-TsAPw6v3ElqJ3PWpvVzLchZH0vxx5fgfgsUEao_RHv08maWN-lmPdh9-VGUhLWULOjIT7wAr8mATnahrZ9h8HNl69xPdlrTiIvTjTwSXTrouNPaHaRVT22A8kPiza7Bucpc3aRdWPx6bpiwyVdbwxSFcntHKho7kmm6lqF)
 
-## SHOW_ELEMENT_TYPE(?hideStereotype)
+## SHOW_ELEMENT_TYPE(?hideStereotype, ?hidePersonType)
 
 Instead of `<<stereotypes>>` is it also possible to show the element type in the technology section.
 This can be enabled with `SHOW_ELEMENT_TYPE()`.
 
-If you use the call `SHOW_LEGEND(false)` then the stereotypes remain visible.
+If you use the call `SHOW_LEGEND(false)` then the stereotypes remain visible (`$hideStereotype` default is `true`).  
+If you use the call `SHOW_ELEMENT_TYPE($hidePersonType=false)` then all persons are displayed with element type too ´(`$hidePersonType` default is `true`).
+
 
 ```plantuml
 @startuml SHOW_ELEMENT_TYPE Sample

--- a/LayoutOptions.md
+++ b/LayoutOptions.md
@@ -8,6 +8,7 @@ C4-PlantUML comes with some layout options.
     - [Overall Guidance](#overall-guidance)
     - [Layout Practices](#layout-practices)
   - [LAYOUT_TOP_DOWN() or LAYOUT_LEFT_RIGHT() or LAYOUT_LANDSCAPE()](#layout_top_down-or-layout_left_right-or-layout_landscape)
+  - [SHOW_ELEMENT_TYPE(?hideStereotype)](#show_element_typehidestereotype)
   - [LAYOUT_WITH_LEGEND() or SHOW_LEGEND(?hideStereotype, ?details)](#layout_with_legend-or-show_legendhidestereotype-details)
   - [SHOW_FLOATING_LEGEND(?alias, ?hideStereotype, ?details) and LEGEND()](#show_floating_legendalias-hidestereotype-details-and-legend)
   - [LAYOUT_AS_SKETCH() and SET_SKETCH_STYLE(?bgColor, ?fontColor, ?warningColor, ?fontName, ?footerWarning, ?footerText)](#layout_as_sketch-and-set_sketch_stylebgcolor-fontcolor-warningcolor-fontname-footerwarning-footertext)
@@ -140,6 +141,32 @@ SHOW_LEGEND()
 ```
 
 [![LAYOUT_LANDSCAPE Sample - open link](https://www.plantuml.com/plantuml/svg/NOzFRvj04CNlV8gjUmYM75kfUkef5ApaG1nae55FQ0sJUANzizeTXAAgtxqpCNQiSa7lDxFllRcFA0EEHeio-_tSDbsPxOewpwgjgANn6f8lolPw740S4NtyiTa4EQtV51x7mnWXzCuYM5ptpcoybfQzRYCEMXqs-VVRYb7xL6wCZ0Y1K9VJ2waiXBMdtIJvFpXT9aa58JgRoi4eknABZFygOf3emcAPrEzaPhgVRhI33EzfVxSIDwU-Dqln9n7qNMBI2GwTz9vyNk0WCk-rwYKgPnU4ygyhaTNLUhTjw4a0yMrz9vv-vJpBj7PJ57nc5EW4tUWbhPXHew8iqKmA4O90PK1JLgHkV-TsAPw6v3ElqJ3PWpvVzLchZH0vxx5fgfgsUEao_RHv08maWN-lmPdh9-VGUhLWULOjIT7wAr8mATnahrZ9h8HNl69xPdlrTiIvTjTwSXTrouNPaHaRVT22A8kPiza7Bucpc3aRdWPx6bpiwyVdbwxSFcntHKho7kmm6lqF "LAYOUT_LANDSCAPE Sample")](https://www.plantuml.com/plantuml/uml/NOzFRvj04CNlV8gjUmYM75kfUkef5ApaG1nae55FQ0sJUANzizeTXAAgtxqpCNQiSa7lDxFllRcFA0EEHeio-_tSDbsPxOewpwgjgANn6f8lolPw740S4NtyiTa4EQtV51x7mnWXzCuYM5ptpcoybfQzRYCEMXqs-VVRYb7xL6wCZ0Y1K9VJ2waiXBMdtIJvFpXT9aa58JgRoi4eknABZFygOf3emcAPrEzaPhgVRhI33EzfVxSIDwU-Dqln9n7qNMBI2GwTz9vyNk0WCk-rwYKgPnU4ygyhaTNLUhTjw4a0yMrz9vv-vJpBj7PJ57nc5EW4tUWbhPXHew8iqKmA4O90PK1JLgHkV-TsAPw6v3ElqJ3PWpvVzLchZH0vxx5fgfgsUEao_RHv08maWN-lmPdh9-VGUhLWULOjIT7wAr8mATnahrZ9h8HNl69xPdlrTiIvTjTwSXTrouNPaHaRVT22A8kPiza7Bucpc3aRdWPx6bpiwyVdbwxSFcntHKho7kmm6lqF)
+
+## SHOW_ELEMENT_TYPE(?hideStereotype)
+
+Instead of `<<stereotypes>>` is it also possible to show the element type in the technology section.
+This can be enabled with `SHOW_ELEMENT_TYPE()`.
+
+If you use the call `SHOW_LEGEND(false)` then the stereotypes remain visible.
+
+```plantuml
+@startuml SHOW_ELEMENT_TYPE Sample
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+SHOW_ELEMENT_TYPE()
+
+Person(admin, "Administrator")
+System_Boundary(c1, 'Sample') {
+    Container(web_app, "Web Application", "C#, ASP.NET Core 2.1 MVC", "Allows users to compare multiple Twitter timelines")
+}
+System(twitter, "Twitter")
+
+Rel(admin, web_app, "Uses", "HTTPS")
+Rel(web_app, twitter, "Gets tweets from", "HTTPS")
+@enduml
+```
+
+[![SHOW_ELEMENT_TYPE Sample - open link](https://www.plantuml.com/plantuml/svg/PKzFwzf04BtlfvZQWn4qmT9JJwOXr8FQqCHAJs6JJEl2_bbs9mGf_UwTeDN2Ro_3pllptkmYoK2ZqL3llrxQyb0UorFJDZ-g4cffl4RnJjbUZmF2bSZ7JraMv9J-KdGTkp5Yw9qbj9JspcHUIpkRRI8DMdLPyN5JpQlpyP0P6Ga3hzg25L9P3AbdhX1lafEL41M6w6mY1wFi6XRvF5Ma8Cc5nKhKDtOpxMStsa66Mz9lrx2y5rwkuBS0Vi-SPCAkbTwppmKxoBtNgfUad5tmgdY_XhokqbFPi2GWV4YtSFnUp5YkjPiYp7T680Tyf9TCCQCcnLdGJ8e80v0og3ahShS_ZtO9tK7sUT0O5DzG_xlgLUiSMSbptpHLpQoPz4HVDb-G8dzn7Z-3C_zBTcY7qUY_ "SHOW_ELEMENT_TYPE Sample")](https://www.plantuml.com/plantuml/uml/PKzFwzf04BtlfvZQWn4qmT9JJwOXr8FQqCHAJs6JJEl2_bbs9mGf_UwTeDN2Ro_3pllptkmYoK2ZqL3llrxQyb0UorFJDZ-g4cffl4RnJjbUZmF2bSZ7JraMv9J-KdGTkp5Yw9qbj9JspcHUIpkRRI8DMdLPyN5JpQlpyP0P6Ga3hzg25L9P3AbdhX1lafEL41M6w6mY1wFi6XRvF5Ma8Cc5nKhKDtOpxMStsa66Mz9lrx2y5rwkuBS0Vi-SPCAkbTwppmKxoBtNgfUad5tmgdY_XhokqbFPi2GWV4YtSFnUp5YkjPiYp7T680Tyf9TCCQCcnLdGJ8e80v0og3ahShS_ZtO9tK7sUT0O5DzG_xlgLUiSMSbptpHLpQoPz4HVDb-G8dzn7Z-3C_zBTcY7qUY_)
 
 ## LAYOUT_WITH_LEGEND() or SHOW_LEGEND(?hideStereotype, ?details)
 

--- a/percy/TestEmptyLabel.puml
+++ b/percy/TestEmptyLabel.puml
@@ -8,8 +8,8 @@
 
 LAYOUT_TOP_DOWN()
 
-!$img="img:https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Test-Logo.svg/80px-Test-Logo.svg.png"
-!$imgSmall="img:https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Test-Logo.svg/20px-Test-Logo.svg.png"
+!$img="img:https://plantuml.com/logo3.png{scale=1.0}"
+!$imgSmall="img:https://plantuml.com/logo3.png{scale=0.25}"
 
 ' SHOW_PERSON_OUTLINE()
 SHOW_PERSON_PORTRAIT()

--- a/percy/TestShowElementType.puml
+++ b/percy/TestShowElementType.puml
@@ -1,0 +1,25 @@
+@startuml
+
+!theme C4Language_japanese from <C4/themes>
+
+' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
+!if %variable_exists("RELATIVE_INCLUDE")
+  !include %get_variable_value("RELATIVE_INCLUDE")/C4_Container.puml
+!else
+  !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!endif
+
+SHOW_ELEMENT_TYPE()
+
+Person(admin, "Administrator")
+System_Boundary(c1, 'Sample') {
+    Container(web_app, "Web Application", "C#, ASP.NET Core 2.1 MVC", "Allows users to compare multiple Twitter timelines")
+}
+System(twitter, "Twitter")
+
+Rel(admin, web_app, "Uses", "HTTPS")
+Rel(web_app, twitter, "Gets tweets from", "HTTPS")
+
+' typically optional, only that text can be compared
+SHOW_LEGEND()
+@enduml

--- a/percy/TestShowElementType.puml
+++ b/percy/TestShowElementType.puml
@@ -1,6 +1,11 @@
 @startuml
 
-!theme C4Language_japanese from <C4/themes>
+!if %variable_exists("RELATIVE_INCLUDE")
+'   language themes not working on build agent (percy tests)
+'   !theme C4Language_japanese from %get_variable_value("RELATIVE_INCLUDE")/themes
+!else
+  !theme C4Language_japanese from https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/themes
+!endif
 
 ' convert it with additional command line argument -DRELATIVE_INCLUDE="./.." to use locally
 !if %variable_exists("RELATIVE_INCLUDE")


### PR DESCRIPTION
related to [#415 - comment: element type](https://github.com/plantuml-stdlib/C4-PlantUML/issues/415#issuecomment-4138508506)

## SHOW_ELEMENT_TYPE(?hideStereotype)

Instead of `<<stereotypes>>` is it also possible to show the element type in the technology section.
This can be enabled with `SHOW_ELEMENT_TYPE()`.

If you use the call `SHOW_LEGEND(false)` then the stereotypes remain visible.

```plantuml
@startuml SHOW_ELEMENT_TYPE Sample
!include https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml

SHOW_ELEMENT_TYPE()

Person(admin, "Administrator")
System_Boundary(c1, 'Sample') {
    Container(web_app, "Web Application", "C#, ASP.NET Core 2.1 MVC", "Allows users to compare multiple Twitter timelines")
}
System(twitter, "Twitter")

Rel(admin, web_app, "Uses", "HTTPS")
Rel(web_app, twitter, "Gets tweets from", "HTTPS")
@enduml
```

[![SHOW_ELEMENT_TYPE Sample - open link](https://www.plantuml.com/plantuml/svg/PL3DpjCm4BpxAPPoQ2gLH4MSE3L44Jsq9I8f5QV8JHPYuH_BtYXKY7TdevRsapvVLjwPtPdPRIGPQ3GQwjsNSrlkoqDvRDhcUrL2BOtNADues-cnHnY8VFoOPK5EwKz5mtWP8uREMK9BQUTCzak5ReWqPCM7TvMMbaw7VOQ_6U-nvsPRC5agYo7rh2d4Az5a9KI58JgRoDuekuP5FbSLAKXoOR4IzJKIclQJ6sqlmpNfDcjOthmkL_170B-7JZBXfPNUyvupNY3tNgjEad9smQtYxHhokagFPSCZ0U5zke73jsB6SgtT566E684SS3ulcM96JOgre9aK4GOWPL2pLcHlV-_k4hg1lETEOr1yHVq_rTFMAV8arrtJL3MpPj83VQxvZ1JvYtFv4PnvERBb-_8v_m40 "SHOW_ELEMENT_TYPE Sample")](https://www.plantuml.com/plantuml/uml/PL3DpjCm4BpxAPPoQ2gLH4MSE3L44Jsq9I8f5QV8JHPYuH_BtYXKY7TdevRsapvVLjwPtPdPRIGPQ3GQwjsNSrlkoqDvRDhcUrL2BOtNADues-cnHnY8VFoOPK5EwKz5mtWP8uREMK9BQUTCzak5ReWqPCM7TvMMbaw7VOQ_6U-nvsPRC5agYo7rh2d4Az5a9KI58JgRoDuekuP5FbSLAKXoOR4IzJKIclQJ6sqlmpNfDcjOthmkL_170B-7JZBXfPNUyvupNY3tNgjEad9smQtYxHhokagFPSCZ0U5zke73jsB6SgtT566E684SS3ulcM96JOgre9aK4GOWPL2pLcHlV-_k4hg1lETEOr1yHVq_rTFMAV8arrtJL3MpPj83VQxvZ1JvYtFv4PnvERBb-_8v_m40)

The description can be found in the [(extended) LayoutOptions.md](https://github.com/kirchsth/C4-PlantUML/blob/extended/LayoutOptions.md#show_element_typehidestereotype) too

The changes can be checked via the extended branch. ,
@TheJanzap, @Potherca: can you please review my changes.

Thank you and best regards
Helmut 

PS.: Additional I updated the percy tests that no (outdated) node.js v20 is required; and the TestEmptyLabel.puml that no wikimedia images are required (could not be loaded anymore)



